### PR TITLE
feat rabbitmq: change default port so that default distribution port doesnt clash with ip_local_port_range

### DIFF
--- a/testsuite/databases/rabbitmq/service.py
+++ b/testsuite/databases/rabbitmq/service.py
@@ -6,8 +6,8 @@ from testsuite.environment import utils
 
 from . import classes
 
-DEFAULT_RABBITMQ_TCP_PORT = 19002
-DEFAULT_RABBITMQ_EPMD_PORT = 19003
+DEFAULT_RABBITMQ_TCP_PORT = 8672
+DEFAULT_RABBITMQ_EPMD_PORT = 8673
 
 SERVICE_SCRIPT_PATH = pathlib.Path(__file__).parent.joinpath(
     'scripts/service-rabbitmq'


### PR DESCRIPTION
Default rabbitmq inter-node and CLI tools communication port is (AMQP port + 20000), with previous value of AMQP port being 19002 it used to clash with locals ports in userver CI