### PR TITLE
feat mockserver: replace absolute url with relative url in logs

### DIFF
--- a/testsuite/mockserver/server.py
+++ b/testsuite/mockserver/server.py
@@ -262,7 +262,7 @@ class Server:
             '_type': 'mockserver_request',
             'timestamp': datetime.datetime.utcnow(),
             'method': request.method,
-            'url': request.url,
+            'url': request.rel_url,
         }
         for header, key in _LOGGER_HEADERS:
             if header in request.headers:


### PR DESCRIPTION
Surprisingly constructing a url takes a lot of time:
![image](https://github.com/yandex/yandex-taxi-testsuite/assets/10709593/e316fe7a-098d-403a-a15a-d7d369dc84e0)

It can be seen that it takes basically half of all the time spent in request handling, and all it does is adding something like `http://localhost:<port>` to the log string, when relative url (like `/my-mockserver-handler/v1/some-path?...`) would do just fine