### PR TITLE
fix utcnow() deprecation warning

### DIFF
--- a/docs/other_plugins.rst
+++ b/docs/other_plugins.rst
@@ -54,7 +54,7 @@ used in a particular test: ``@pytest.mark.now('2016-12-01T12:00:00')`` or
 ``@pytest.mark.now(enabled=True)``.
 
 If time is not specified in ``@pytest.mark.now``, then
-``datetime.datetime.utcnow()`` value at the start of test is used as time value
+``datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)`` value at the start of test is used as time value
 until it is modified by calling ``mocked_time.set(...)`` or
 ``mocked_time.sleep(...)``
 

--- a/docs/other_plugins.rst
+++ b/docs/other_plugins.rst
@@ -54,7 +54,7 @@ used in a particular test: ``@pytest.mark.now('2016-12-01T12:00:00')`` or
 ``@pytest.mark.now(enabled=True)``.
 
 If time is not specified in ``@pytest.mark.now``, then
-``datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)`` value at the start of test is used as time value
+current time at UTC timezone is used at the start of test as time value
 until it is modified by calling ``mocked_time.set(...)`` or
 ``mocked_time.sleep(...)``
 

--- a/tests/plugins/test_mocked_time.py
+++ b/tests/plugins/test_mocked_time.py
@@ -21,9 +21,7 @@ def test_disabled_mocked_time_raises_on_usage_attempt(mocked_time):
     assert not mocked_time.is_enabled
 
     with pytest.raises(mocked_time_module.DisabledUsageError):
-        mocked_time.set(
-            datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-        )
+        mocked_time.set(datetime.datetime.now(datetime.timezone.utc))
 
     with pytest.raises(mocked_time_module.DisabledUsageError):
         mocked_time.sleep(2)

--- a/tests/plugins/test_mocked_time.py
+++ b/tests/plugins/test_mocked_time.py
@@ -21,7 +21,9 @@ def test_disabled_mocked_time_raises_on_usage_attempt(mocked_time):
     assert not mocked_time.is_enabled
 
     with pytest.raises(mocked_time_module.DisabledUsageError):
-        mocked_time.set(datetime.datetime.utcnow())
+        mocked_time.set(
+            datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        )
 
     with pytest.raises(mocked_time_module.DisabledUsageError):
         mocked_time.sleep(2)

--- a/testsuite/mockserver/server.py
+++ b/testsuite/mockserver/server.py
@@ -1,5 +1,4 @@
 import contextlib
-import datetime
 import itertools
 import logging
 import pathlib
@@ -19,6 +18,7 @@ from testsuite.utils import compat
 from testsuite.utils import http
 from testsuite.utils import net as net_utils
 from testsuite.utils import url_util
+from testsuite import utils
 
 from . import classes
 from . import exceptions
@@ -281,7 +281,7 @@ class Server:
             return
         fields = {
             '_type': 'mockserver_request',
-            'timestamp': compat.utcnow(),
+            'timestamp': utils.utcnow(),
             'method': request.method,
             'url': request.rel_url,
         }

--- a/testsuite/mockserver/server.py
+++ b/testsuite/mockserver/server.py
@@ -281,7 +281,9 @@ class Server:
             return
         fields = {
             '_type': 'mockserver_request',
-            'timestamp': datetime.datetime.utcnow(),
+            'timestamp': datetime.datetime.now(datetime.timezone.utc).replace(
+                tzinfo=None
+            ),
             'method': request.method,
             'url': request.rel_url,
         }

--- a/testsuite/mockserver/server.py
+++ b/testsuite/mockserver/server.py
@@ -281,9 +281,7 @@ class Server:
             return
         fields = {
             '_type': 'mockserver_request',
-            'timestamp': datetime.datetime.now(datetime.timezone.utc).replace(
-                tzinfo=None
-            ),
+            'timestamp': compat.utcnow(),
             'method': request.method,
             'url': request.rel_url,
         }

--- a/testsuite/plugins/mocked_time.py
+++ b/testsuite/plugins/mocked_time.py
@@ -37,18 +37,13 @@ class MockedTime:
         """:returns: current value of mock time"""
         if self._is_enabled:
             return self._now
-        return utils.compat.utcnow()
+        return utils.utcnow()
 
     def set(self, time: datetime.datetime):
         """Set mock time value"""
         if not self._is_enabled:
             raise DisabledUsageError(MOCK_TIME_DISABLED_MESSAGE)
-        self._now = time
-
-        if self._now.tzinfo is not None:
-            self._now = self._now.astimezone(datetime.timezone.utc).replace(
-                tzinfo=None
-            )
+        self._now = utils.to_utc(time)
 
     @property
     def is_enabled(self) -> bool:
@@ -92,10 +87,10 @@ def mocked_time(_mocked_time_enabled, now) -> MockedTime:
 def now(request) -> datetime.datetime:
     marker = request.node.get_closest_marker('now')
     if not marker or not marker.args:
-        return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        return utils.utcnow()
     stamp = marker.args[0]
     if isinstance(stamp, int):
-        return datetime.datetime.utcfromtimestamp(stamp)
+        return utils.fromtimestamp(stamp, tz=datetime.timezone.utc)
     return utils.to_utc(dateutil.parser.parse(stamp))
 
 

--- a/testsuite/plugins/mocked_time.py
+++ b/testsuite/plugins/mocked_time.py
@@ -37,13 +37,18 @@ class MockedTime:
         """:returns: current value of mock time"""
         if self._is_enabled:
             return self._now
-        return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        return utils.compat.utcnow()
 
     def set(self, time: datetime.datetime):
         """Set mock time value"""
         if not self._is_enabled:
             raise DisabledUsageError(MOCK_TIME_DISABLED_MESSAGE)
         self._now = time
+
+        if self._now.tzinfo is not None:
+            self._now = self._now.astimezone(datetime.timezone.utc).replace(
+                tzinfo=None
+            )
 
     @property
     def is_enabled(self) -> bool:

--- a/testsuite/plugins/mocked_time.py
+++ b/testsuite/plugins/mocked_time.py
@@ -37,7 +37,7 @@ class MockedTime:
         """:returns: current value of mock time"""
         if self._is_enabled:
             return self._now
-        return datetime.datetime.utcnow()
+        return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 
     def set(self, time: datetime.datetime):
         """Set mock time value"""
@@ -87,7 +87,7 @@ def mocked_time(_mocked_time_enabled, now) -> MockedTime:
 def now(request) -> datetime.datetime:
     marker = request.node.get_closest_marker('now')
     if not marker or not marker.args:
-        return datetime.datetime.utcnow()
+        return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
     stamp = marker.args[0]
     if isinstance(stamp, int):
         return datetime.datetime.utcfromtimestamp(stamp)

--- a/testsuite/plugins/mocked_time.py
+++ b/testsuite/plugins/mocked_time.py
@@ -90,7 +90,7 @@ def now(request) -> datetime.datetime:
         return utils.utcnow()
     stamp = marker.args[0]
     if isinstance(stamp, int):
-        return utils.fromtimestamp(stamp, tz=datetime.timezone.utc)
+        return utils.utcfromtimestamp(stamp)
     return utils.to_utc(dateutil.parser.parse(stamp))
 
 

--- a/testsuite/utils/__init__.py
+++ b/testsuite/utils/__init__.py
@@ -1,5 +1,7 @@
 import datetime
 
+from .cached_property import cached_property
+
 
 def to_utc(stamp: datetime.datetime) -> datetime.datetime:
     if stamp.tzinfo is not None:

--- a/testsuite/utils/__init__.py
+++ b/testsuite/utils/__init__.py
@@ -1,15 +1,22 @@
-# flake8: noqa
-import pytz
-
-from .cached_property import cached_property
+import datetime
 
 
-def to_utc(stamp):
+def to_utc(stamp: datetime.datetime) -> datetime.datetime:
     if stamp.tzinfo is not None:
-        stamp = stamp.astimezone(pytz.utc).replace(tzinfo=None)
+        stamp = stamp.astimezone(datetime.timezone.utc).replace(tzinfo=None)
     return stamp
 
 
-def timestring(stamp):
+def timestring(stamp: datetime.datetime) -> str:
     stamp = to_utc(stamp)
     return stamp.strftime('%Y-%m-%dT%H:%M:%S.%f+0000')
+
+
+def utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+
+
+def utcfromtimestamp(stamp: int) -> datetime.datetime:
+    return datetime.datetime.fromtimestamp(
+        stamp, tz=datetime.timezone.utc
+    ).replace(tzinfo=None)

--- a/testsuite/utils/compat.py
+++ b/testsuite/utils/compat.py
@@ -1,9 +1,4 @@
 import contextlib
-import datetime
-
-
-def utcnow() -> datetime.datetime:
-    return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 
 
 # Required for python3.6 compatibility

--- a/testsuite/utils/compat.py
+++ b/testsuite/utils/compat.py
@@ -1,4 +1,10 @@
 import contextlib
+import datetime
+
+
+def utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+
 
 # Required for python3.6 compatibility
 if not hasattr(contextlib, 'asynccontextmanager'):

--- a/testsuite/utils/json_util.py
+++ b/testsuite/utils/json_util.py
@@ -3,7 +3,7 @@ import datetime
 from bson import json_util
 
 from testsuite.utils import object_hook as object_hook_util
-from testsuite.utils import compat as compat
+from testsuite import utils
 
 
 def loads(string, *args, **kwargs):
@@ -59,6 +59,6 @@ def default(obj):
 def relative_dates_default(obj):
     """Add ``$dateDiff`` hook to ``bson.json_util.default``."""
     if isinstance(obj, datetime.datetime):
-        diff = obj.replace(tzinfo=None) - compat.utcnow()
+        diff = obj.replace(tzinfo=None) - utils.utcnow()
         return {'$dateDiff': diff.total_seconds()}
     return default(obj)

--- a/testsuite/utils/json_util.py
+++ b/testsuite/utils/json_util.py
@@ -3,6 +3,7 @@ import datetime
 from bson import json_util
 
 from testsuite.utils import object_hook as object_hook_util
+from testsuite.utils import compat as compat
 
 
 def loads(string, *args, **kwargs):
@@ -58,8 +59,6 @@ def default(obj):
 def relative_dates_default(obj):
     """Add ``$dateDiff`` hook to ``bson.json_util.default``."""
     if isinstance(obj, datetime.datetime):
-        diff = obj.replace(tzinfo=None) - datetime.datetime.now(
-            datetime.timezone.utc
-        ).replace(tzinfo=None)
+        diff = obj.replace(tzinfo=None) - compat.utcnow()
         return {'$dateDiff': diff.total_seconds()}
     return default(obj)

--- a/testsuite/utils/json_util.py
+++ b/testsuite/utils/json_util.py
@@ -22,7 +22,7 @@ def substitute(json_obj, *, object_hook=None):
     """Create transformed json by making substitutions:
 
     {"$mockserver": "/path", "$schema": true} -> "http://localhost:9999/path"
-    {"$dateDiff": 10} -> datetime.utcnow() + timedelta(seconds=10)
+    {"$dateDiff": 10} -> datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None) + timedelta(seconds=10)
     """
     hook = object_hook_util.build_object_hook(object_hook=object_hook)
     return object_hook_util.substitute(json_obj, hook)
@@ -58,6 +58,8 @@ def default(obj):
 def relative_dates_default(obj):
     """Add ``$dateDiff`` hook to ``bson.json_util.default``."""
     if isinstance(obj, datetime.datetime):
-        diff = obj.replace(tzinfo=None) - datetime.datetime.utcnow()
+        diff = obj.replace(tzinfo=None) - datetime.datetime.now(
+            datetime.timezone.utc
+        ).replace(tzinfo=None)
         return {'$dateDiff': diff.total_seconds()}
     return default(obj)


### PR DESCRIPTION
replace datetime.utcnow() withdatetime.now(datetime.timezone.utc).replace(tzinfo=None)