### PR TITLE
Reliable get_free_port()

### DIFF
--- a/tests/plugins/test_network.py
+++ b/tests/plugins/test_network.py
@@ -6,5 +6,7 @@ from testsuite.plugins import network
 @pytest.mark.nofilldb
 def test_get_free_port_error(get_free_port):
     with pytest.raises(network.NoEnabledPorts):
+        ports = set()
         for _ in range(network.MAX_PORTS_NUMBER + 1):
-            get_free_port()
+            ports.append(get_free_port())
+        assert len(ports) == network.MAX_PORTS_NUMBER + 1

--- a/tests/plugins/test_network.py
+++ b/tests/plugins/test_network.py
@@ -5,7 +5,9 @@ from testsuite.plugins import network
 
 @pytest.mark.nofilldb
 def test_get_free_port_error(get_free_port):
+    max_ports = 101
+
     ports = set()
-    for _ in range(MAX_PORTS_NUMBER):
+    for _ in range(max_ports):
         ports.add(get_free_port())
-    assert len(ports) == MAX_PORTS_NUMBER
+    assert len(ports) == max_ports, 'get_free_port() returns duplicate ports'

--- a/tests/plugins/test_network.py
+++ b/tests/plugins/test_network.py
@@ -5,9 +5,7 @@ from testsuite.plugins import network
 
 @pytest.mark.nofilldb
 def test_get_free_port_error(get_free_port):
-    MAX_PORTS_NUMBER = 101
-    with pytest.raises(network.NoEnabledPorts):
-        ports = set()
-        for _ in range(MAX_PORTS_NUMBER):
-            ports.add(get_free_port())
-        assert len(ports) == MAX_PORTS_NUMBER
+    ports = set()
+    for _ in range(MAX_PORTS_NUMBER):
+        ports.add(get_free_port())
+    assert len(ports) == MAX_PORTS_NUMBER

--- a/tests/plugins/test_network.py
+++ b/tests/plugins/test_network.py
@@ -5,8 +5,9 @@ from testsuite.plugins import network
 
 @pytest.mark.nofilldb
 def test_get_free_port_error(get_free_port):
+    MAX_PORTS_NUMBER = 101
     with pytest.raises(network.NoEnabledPorts):
         ports = set()
-        for _ in range(network.MAX_PORTS_NUMBER + 1):
-            ports.append(get_free_port())
-        assert len(ports) == network.MAX_PORTS_NUMBER + 1
+        for _ in range(MAX_PORTS_NUMBER):
+            ports.add(get_free_port())
+        assert len(ports) == MAX_PORTS_NUMBER

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -31,7 +31,7 @@ def _get_ipv6_localhost_or_fallback() -> str:
 
 
 _IPV6_AF_OR_FALLBACK = _get_ipv6_localhost_or_fallback()
-_LOCALHOST = ('127.0.0.1' if _IPV6_AF_OR_FALLBACK == socket.AF_INET else '::')
+_LOCALHOST = '127.0.0.1' if _IPV6_AF_OR_FALLBACK == socket.AF_INET else '::'
 
 
 def _is_port_free(port_num: int) -> bool:
@@ -91,9 +91,6 @@ def _get_free_port_range_based() -> typing.Callable[[], int]:
 def get_free_port() -> typing.Callable[[], int]:
     """
     Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
-
-    Provides strong guarantee that no other application could bind
-    to that port via bind(('', 0)).
     """
     if platform.system() == 'Linux':
         return _get_free_port_sock_storing()

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -67,16 +67,16 @@ def _get_free_port_sock_storing(
 ) -> typing.Callable[[], int]:
     # Relies on https://github.com/torvalds/linux/commit/aacd9289af8b82f5fb01b
     def _get_free_port():
-        nonlocal sock_list
-
         sock = socket.socket(socket_af, socket.SOCK_STREAM)
         try:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.bind((host, 0))
-            sock_list.add(sock)
+            sock_list.add(sock)  # shared variable
             return sock.getsockname()[1]
         except OSError:
             raise NoEnabledPorts()
+
+    return _get_free_port
 
 
 def _get_free_port_range_based(

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -31,7 +31,6 @@ def _get_ipv6_af_or_fallback():
     return socket.AF_INET
 
 
-
 def _is_port_free(port_num: int, socket_af, host: str) -> bool:
     sock = socket.socket(socket_af, socket.SOCK_STREAM)
     try:
@@ -53,7 +52,9 @@ async def _get_open_sock_list_impl():
 
 
 def _get_free_port_sock_storing(
-    socket_af, host: str, sock_list: set,
+    socket_af,
+    host: str,
+    sock_list: set,
 ) -> typing.Callable[[], int]:
     # Relies on https://github.com/torvalds/linux/commit/aacd9289af8b82f5fb01b
     def _get_free_port():
@@ -70,7 +71,8 @@ def _get_free_port_sock_storing(
 
 
 async def _get_free_port_range_based(
-    socket_af, host: str,
+    socket_af,
+    host: str,
 ) -> typing.Callable[[], int]:
     port = 61000
 
@@ -91,7 +93,9 @@ async def _get_free_port_range_based(
 
 @pytest.fixture(scope='session')
 def get_free_port(
-    _get_ipv6_af_or_fallback, _get_localhost, _get_open_sock_list_impl,
+    _get_ipv6_af_or_fallback,
+    _get_localhost,
+    _get_open_sock_list_impl,
 ) -> typing.Callable[[], int]:
     """
     Returns an ephemeral TCP port that is free for IPv4 and for IPv6.

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -16,43 +16,61 @@ class NoEnabledPorts(BaseError):
     """Raised if there are not free ports for worker"""
 
 
-def _is_port_free(port_num: int) -> bool:
-    global socket_af
-    socket_af = socket.AF_INET
-    if hasattr(socket, 'AF_INET6'):
-        socket_af = socket.AF_INET6
+def _get_ipv6_localhost_or_fallback() -> str:
+    if not hasattr(socket, 'AF_INET6'):
+        return socket.AF_INET
 
-    sock = socket.socket(socket_af, socket.SOCK_STREAM)
-    addr = ('127.0.0.1' if socket_af == socket.AF_INET else '::', port_num)
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     try:
-        sock.bind(addr)
+        sock.bind(('::', 0))
+        return socket.AF_INET6
+    finally:
+        sock.close()
+
+    return socket.AF_INET
+
+
+_IPV6_AF_OR_FALLBACK = _get_ipv6_localhost_or_fallback()
+_LOCALHOST = ('127.0.0.1' if _IPV6_AF_OR_FALLBACK == socket.AF_INET else '::')
+
+
+def _is_port_free(port_num: int) -> bool:
+    sock = socket.socket(_IPV6_AF_OR_FALLBACK, socket.SOCK_STREAM)
+    try:
+        sock.bind((_LOCALHOST, port_num))
         return True
-    except OSError as err:
-        if socket_af != socket.AF_INET and err.errno == errno.EADDRNOTAVAIL:
-            socket_af = socket.AF_INET
-            return _is_port_free(port_num)
     finally:
         sock.close()
 
     return False
 
 
-@pytest.fixture(scope='session')
-def get_free_port() -> typing.Callable[[], int]:
-    """
-    Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
-    """
+def _get_free_port_sock_storing() -> typing.Callable[[], int]:
+    # Relies on https://github.com/torvalds/linux/commit/aacd9289af8b82f5fb01b
+    sock_list = set()
+
+    def _get_free_port():
+        nonlocal sock_list
+
+        sock = socket.socket(_IPV6_AF_OR_FALLBACK, socket.SOCK_STREAM)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((_LOCALHOST, 0))
+            sock_list.add(sock)
+            return sock.getsockname()[1]
+        except OSError as err:
+            raise NoEnabledPorts()
+
+    try:
+        yield _get_free_port
+    finally:
+        for sock in sock_list:
+            sock.close()
+
+
+def _get_free_port_range_based() -> typing.Callable[[], int]:
     base_port = 30000
     last_port = 65000
-
-    if platform.system() == 'Linux':
-        range_fs = '/proc/sys/net/ipv4/ip_local_port_range'
-        with open(range_fs) as range_file:
-            data = range_file.read()
-        new_base, new_last = data.strip().split()
-        base_port = int(new_base)
-        last_port = int(new_last)
-
     next_port = base_port
 
     def _get_free_port():
@@ -67,3 +85,17 @@ def get_free_port() -> typing.Callable[[], int]:
         raise NoEnabledPorts()
 
     return _get_free_port
+
+
+@pytest.fixture(scope='session')
+def get_free_port() -> typing.Callable[[], int]:
+    """
+    Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
+
+    Provides strong guarantee that no other application could bind
+    to that port via bind(('', 0)).
+    """
+    if platform.system() == 'Linux':
+        return _get_free_port_sock_storing()
+    else:
+        return _get_free_port_range_based()

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -52,7 +52,9 @@ async def _get_open_sock_list_impl():
             sock.close()
 
 
-def _get_free_port_sock_storing(socket_af, host: str, sock_list: set) -> typing.Callable[[], int]:
+def _get_free_port_sock_storing(
+    socket_af, host: str, sock_list: set,
+) -> typing.Callable[[], int]:
     # Relies on https://github.com/torvalds/linux/commit/aacd9289af8b82f5fb01b
     def _get_free_port():
         nonlocal sock_list
@@ -67,9 +69,9 @@ def _get_free_port_sock_storing(socket_af, host: str, sock_list: set) -> typing.
             raise NoEnabledPorts()
 
 
-async def _get_free_port_range_based(socket_af, host: str)
-    -> typing.Callable[[], int]
-:
+async def _get_free_port_range_based(
+    socket_af, host: str,
+) -> typing.Callable[[], int]:
     port = 61000
 
     def _get_free_port():
@@ -88,9 +90,9 @@ async def _get_free_port_range_based(socket_af, host: str)
 
 
 @pytest.fixture(scope='session')
-def get_free_port(_get_ipv6_af_or_fallback, _get_localhost, _get_open_sock_list_impl)
-    -> typing.Callable[[], int]
-:
+def get_free_port(
+    _get_ipv6_af_or_fallback, _get_localhost, _get_open_sock_list_impl,
+) -> typing.Callable[[], int]:
     """
     Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
     """

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -31,6 +31,14 @@ def _get_ipv6_af_or_fallback():
     return socket.AF_INET
 
 
+@pytest.fixture(scope='session')
+def _get_ipv6_localhost_or_fallback(_get_ipv6_af_or_fallback):
+    if _get_ipv6_af_or_fallback == socket.AF_INET:
+        return '127.0.0.1'
+
+    return '::'
+
+
 def _is_port_free(port_num: int, socket_af, host: str) -> bool:
     sock = socket.socket(socket_af, socket.SOCK_STREAM)
     try:
@@ -94,7 +102,7 @@ async def _get_free_port_range_based(
 @pytest.fixture(scope='session')
 def get_free_port(
     _get_ipv6_af_or_fallback,
-    _get_localhost,
+    _get_ipv6_localhost_or_fallback,
     _get_open_sock_list_impl,
 ) -> typing.Callable[[], int]:
     """
@@ -102,7 +110,12 @@ def get_free_port(
     """
     if platform.system() == 'Linux':
         return _get_free_port_sock_storing(
-            _get_ipv6_af_or_fallback, _get_localhost, _get_open_sock_list_impl,
+            _get_ipv6_af_or_fallback,
+            _get_ipv6_localhost_or_fallback,
+            _get_open_sock_list_impl,
         )
 
-    return _get_free_port_range_based(_get_ipv6_af_or_fallback, _get_localhost)
+    return _get_free_port_range_based(
+        _get_ipv6_af_or_fallback,
+        _get_ipv6_localhost_or_fallback,
+    )

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -87,11 +87,11 @@ def _get_free_port_range_based() -> typing.Callable[[], int]:
 
 
 @pytest.fixture(scope='session')
-def get_free_port() -> typing.Callable[[], int]:
+async def get_free_port() -> typing.Callable[[], int]:
     """
     Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
     """
     if platform.system() == 'Linux':
-        return _get_free_port_sock_storing()
-    else:
-        return _get_free_port_range_based()
+        return await _get_free_port_sock_storing()
+
+    return _get_free_port_range_based()

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -28,10 +28,9 @@ def _is_port_free(port_num: int) -> bool:
         sock.bind(addr)
         return True
     except OSError as err:
-        if socket_af != socket.AF_INET:
-            if err.errno == errno.EADDRNOTAVAIL:
-                socket_af = socket.AF_INET
-                return _is_port_free(port_num)
+        if socket_af != socket.AF_INET and err.errno == errno.EADDRNOTAVAIL:
+            socket_af = socket.AF_INET
+            return _is_port_free(port_num)
     finally:
         sock.close()
 

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -92,6 +92,6 @@ async def get_free_port() -> typing.Callable[[], int]:
     Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
     """
     if platform.system() == 'Linux':
-        return _get_free_port_sock_storing()
+        yield _get_free_port_sock_storing()
 
-    return _get_free_port_range_based()
+    yield _get_free_port_range_based()

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -22,7 +22,7 @@ class NoEnabledPorts(BaseError):
 def get_free_port() -> typing.Callable[[], int]:
     """
     Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
-    
+
     Provides strong guarantee that no other application could bind
     to that port via bind(('', 0)).
     """

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -58,7 +58,7 @@ def _get_free_port_sock_storing() -> typing.Callable[[], int]:
             sock.bind((_LOCALHOST, 0))
             sock_list.add(sock)
             return sock.getsockname()[1]
-        except OSError as err:
+        except OSError:
             raise NoEnabledPorts()
 
     try:
@@ -70,11 +70,12 @@ def _get_free_port_sock_storing() -> typing.Callable[[], int]:
 
 def _get_free_port_range_based() -> typing.Callable[[], int]:
     port = 61000
-    
+
     def _get_free_port():
         nonlocal port
 
-        while port > 1:
+        close_to_privileged_ports = 2048
+        while port > close_to_privileged_ports:
             port -= 1
 
             if _is_port_free(port):

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -16,7 +16,8 @@ class NoEnabledPorts(BaseError):
     """Raised if there are not free ports for worker"""
 
 
-def _get_ipv6_localhost_or_fallback() -> str:
+@pytest.fixture(scope='session')
+def _get_ipv6_af_or_fallback():
     if not hasattr(socket, 'AF_INET6'):
         return socket.AF_INET
 
@@ -30,14 +31,11 @@ def _get_ipv6_localhost_or_fallback() -> str:
     return socket.AF_INET
 
 
-_IPV6_AF_OR_FALLBACK = _get_ipv6_localhost_or_fallback()
-_LOCALHOST = '127.0.0.1' if _IPV6_AF_OR_FALLBACK == socket.AF_INET else '::'
 
-
-def _is_port_free(port_num: int) -> bool:
-    sock = socket.socket(_IPV6_AF_OR_FALLBACK, socket.SOCK_STREAM)
+def _is_port_free(port_num: int, socket_af, host: str) -> bool:
+    sock = socket.socket(socket_af, socket.SOCK_STREAM)
     try:
-        sock.bind((_LOCALHOST, port_num))
+        sock.bind((host, port_num))
         return True
     finally:
         sock.close()
@@ -45,30 +43,33 @@ def _is_port_free(port_num: int) -> bool:
     return False
 
 
-async def _get_free_port_sock_storing() -> typing.Callable[[], int]:
-    # Relies on https://github.com/torvalds/linux/commit/aacd9289af8b82f5fb01b
+async def _get_open_sock_list_impl():
     sock_list = set()
-
-    def _get_free_port():
-        nonlocal sock_list
-
-        sock = socket.socket(_IPV6_AF_OR_FALLBACK, socket.SOCK_STREAM)
-        try:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind((_LOCALHOST, 0))
-            sock_list.add(sock)
-            return sock.getsockname()[1]
-        except OSError:
-            raise NoEnabledPorts()
-
     try:
-        yield _get_free_port
+        yield sock_list
     finally:
         for sock in sock_list:
             sock.close()
 
 
-async def _get_free_port_range_based() -> typing.Callable[[], int]:
+def _get_free_port_sock_storing(socket_af, host: str, sock_list: set) -> typing.Callable[[], int]:
+    # Relies on https://github.com/torvalds/linux/commit/aacd9289af8b82f5fb01b
+    def _get_free_port():
+        nonlocal sock_list
+
+        sock = socket.socket(socket_af, socket.SOCK_STREAM)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((host, 0))
+            sock_list.add(sock)
+            return sock.getsockname()[1]
+        except OSError:
+            raise NoEnabledPorts()
+
+
+async def _get_free_port_range_based(socket_af, host: str)
+    -> typing.Callable[[], int]
+:
     port = 61000
 
     def _get_free_port():
@@ -78,20 +79,24 @@ async def _get_free_port_range_based() -> typing.Callable[[], int]:
         while port > close_to_privileged_ports:
             port -= 1
 
-            if _is_port_free(port):
+            if _is_port_free(port, socket_af, host):
                 return port
 
         raise NoEnabledPorts()
 
-    yield _get_free_port
+    return _get_free_port
 
 
 @pytest.fixture(scope='session')
-async def get_free_port() -> typing.Callable[[], int]:
+def get_free_port(_get_ipv6_af_or_fallback, _get_localhost, _get_open_sock_list_impl)
+    -> typing.Callable[[], int]
+:
     """
     Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
     """
     if platform.system() == 'Linux':
-        yield _get_free_port_sock_storing()
+        return _get_free_port_sock_storing(
+            _get_ipv6_af_or_fallback, _get_localhost, _get_open_sock_list_impl,
+        )
 
-    yield _get_free_port_range_based()
+    return _get_free_port_range_based(_get_ipv6_af_or_fallback, _get_localhost)

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -50,6 +50,7 @@ def _is_port_free(port_num: int, socket_af, host: str) -> bool:
     return False
 
 
+@pytest.fixture(scope='session')
 async def _get_open_sock_list_impl():
     sock_list = set()
     try:

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -79,7 +79,7 @@ def _get_free_port_sock_storing(
             raise NoEnabledPorts()
 
 
-async def _get_free_port_range_based(
+def _get_free_port_range_based(
     socket_af,
     host: str,
 ) -> typing.Callable[[], int]:

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -77,8 +77,8 @@ def _get_free_port_range_based() -> typing.Callable[[], int]:
         while port > 1:
             port -= 1
 
-            if _is_port_free(next_port):
-                return next_port
+            if _is_port_free(port):
+                return port
 
         raise NoEnabledPorts()
 

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -25,6 +25,8 @@ def _get_ipv6_af_or_fallback():
     try:
         sock.bind(('::', 0))
         return socket.AF_INET6
+    except OSError:
+        pass
     finally:
         sock.close()
 
@@ -39,7 +41,7 @@ def _get_ipv6_localhost_or_fallback(_get_ipv6_af_or_fallback):
     return '::'
 
 
-def _is_port_free(port_num: int, socket_af, host: str) -> bool:
+def _is_port_free(port_num: int, socket_af: int, host: str) -> bool:
     sock = socket.socket(socket_af, socket.SOCK_STREAM)
     try:
         sock.bind((host, port_num))
@@ -61,7 +63,7 @@ async def _get_open_sock_list_impl():
 
 
 def _get_free_port_sock_storing(
-    socket_af,
+    socket_af: int,
     host: str,
     sock_list: set,
 ) -> typing.Callable[[], int]:
@@ -80,7 +82,7 @@ def _get_free_port_sock_storing(
 
 
 def _get_free_port_range_based(
-    socket_af,
+    socket_af: int,
     host: str,
 ) -> typing.Callable[[], int]:
     port = 61000

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -1,4 +1,5 @@
 import contextlib
+import errno
 import itertools
 import socket
 import typing
@@ -36,18 +37,22 @@ def get_free_port() -> typing.Callable[[], int]:
         nonlocal sock_list
 
         sock = socket.socket(socket_af, socket.SOCK_STREAM)
-        with contextlib.closing(sock):
-            addr = ('127.0.0.1' if socket_af == socket.AF_INET else '::', 0)
-            try:
-                sock.bind(addr)
-                sock_list.append(sock)
-                return sock.getsockname()[1]
-            except OSError as err:
-                if socket_af != socket.AF_INET:
-                    if err.errno == errno.EADDRNOTAVAIL:
-                        socket_af = socket.AF_INET
-                        return _get_free_port()
+        addr = ('127.0.0.1' if socket_af == socket.AF_INET else '::', 0)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(addr)
+            sock_list.append(sock)
+            return sock.getsockname()[1]
+        except OSError as err:
+            if socket_af != socket.AF_INET:
+                if err.errno == errno.EADDRNOTAVAIL:
+                    socket_af = socket.AF_INET
+                    return _get_free_port()
 
         raise NoEnabledPorts()
 
-    return _get_free_port
+    try:
+        yield _get_free_port
+    finally:
+        for sock in sock_list:
+            sock.close()

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -45,7 +45,7 @@ def _is_port_free(port_num: int) -> bool:
     return False
 
 
-def _get_free_port_sock_storing() -> typing.Callable[[], int]:
+async def _get_free_port_sock_storing() -> typing.Callable[[], int]:
     # Relies on https://github.com/torvalds/linux/commit/aacd9289af8b82f5fb01b
     sock_list = set()
 
@@ -68,7 +68,7 @@ def _get_free_port_sock_storing() -> typing.Callable[[], int]:
             sock.close()
 
 
-def _get_free_port_range_based() -> typing.Callable[[], int]:
+async def _get_free_port_range_based() -> typing.Callable[[], int]:
     port = 61000
 
     def _get_free_port():
@@ -83,7 +83,7 @@ def _get_free_port_range_based() -> typing.Callable[[], int]:
 
         raise NoEnabledPorts()
 
-    return _get_free_port
+    yield _get_free_port
 
 
 @pytest.fixture(scope='session')
@@ -92,6 +92,6 @@ async def get_free_port() -> typing.Callable[[], int]:
     Returns an ephemeral TCP port that is free for IPv4 and for IPv6.
     """
     if platform.system() == 'Linux':
-        return await _get_free_port_sock_storing()
+        return _get_free_port_sock_storing()
 
     return _get_free_port_range_based()

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -69,18 +69,16 @@ def _get_free_port_sock_storing() -> typing.Callable[[], int]:
 
 
 def _get_free_port_range_based() -> typing.Callable[[], int]:
-    base_port = 30000
-    last_port = 65000
-    next_port = base_port
-
+    port = 61000
+    
     def _get_free_port():
-        nonlocal next_port
+        nonlocal port
 
-        while next_port <= last_port:
-            next_port += 1
+        while port > 1:
+            port -= 1
 
-            if _is_port_free(next_port - 1):
-                return next_port - 1
+            if _is_port_free(next_port):
+                return next_port
 
         raise NoEnabledPorts()
 

--- a/testsuite/plugins/network.py
+++ b/testsuite/plugins/network.py
@@ -6,9 +6,6 @@ import typing
 
 import pytest
 
-BASE_PORT = 30000
-MAX_PORTS_NUMBER = 100
-
 
 class BaseError(Exception):
     """Base class for errors from this module."""
@@ -41,7 +38,7 @@ def get_free_port() -> typing.Callable[[], int]:
         try:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.bind(addr)
-            sock_list.append(sock)
+            sock_list.add(sock)
             return sock.getsockname()[1]
         except OSError as err:
             if socket_af != socket.AF_INET:


### PR DESCRIPTION
* get_free_port() not attempts to find port that is open on IPv6 **and** IPv4, rather than just finding a free port on a random interface
* get_free_port() now does not close the bound socket on Linux, so that the address could not be reused by other application via `bind(???, 0)`
* added some docs