### PR TITLE
Fetch original path from aiohttp.response

### DIFF
--- a/tests/plugins/mockserver/test_fixture.py
+++ b/tests/plugins/mockserver/test_fixture.py
@@ -81,3 +81,19 @@ async def test_prefix_handler(
     response = await mockserver_client.get('test123')
     assert response.status_code == 200
     assert test.next_call()
+
+
+async def test_request_encoding(
+    mockserver: fixture_types.MockserverFixture,
+    mockserver_client: service_client.Client,
+):
+    @mockserver.handler('/test', prefix=True)
+    def mock(request: fixture_types.MockserverRequest):
+        return mockserver.make_response(
+            'test', 200, content_type='text/csv', charset='utf-16le'
+        )
+
+    response = await mockserver_client.get('test')
+    assert response.status_code == 200
+    assert response.encoding == 'utf-16-le'
+    assert response.content_type == 'text/csv'

--- a/tests/plugins/mockserver/test_proxy.py
+++ b/tests/plugins/mockserver/test_proxy.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import pytest
+
+from testsuite._internal import fixture_types
+
+
+@pytest.fixture
+def simple_client(mockserver_info):
+    async def client(path: str):
+        async with asyncio.timeout(10):
+            reader, writer = await asyncio.open_connection(
+                mockserver_info.host, mockserver_info.port
+            )
+
+            request = f'GET {path} HTTP/1.0\r\n' f'\r\n'
+            writer.write(request.encode())
+            await writer.drain()
+
+            data = await reader.read()
+            writer.close()
+            await writer.wait_closed()
+
+            lines = data.splitlines()
+            assert len(lines) > 1
+            assert lines[0].decode('utf-8') == ('HTTP/1.0 200 OK'), data
+
+    return client
+
+
+@pytest.mark.parametrize(
+    'mock_url, request_path, expected_path',
+    [
+        ('/foo', '/foo/abc', '/foo/abc'),
+        ('/foo', '/foo/abc?a=b', '/foo/abc'),
+        ('/foo', '/foo/bar%20maurice?a=b', '/foo/bar maurice'),
+        ('http://foo/', 'http://foo/abc', 'http://foo/abc'),
+        ('http://foo/', 'http://foo/abc?a=b', 'http://foo/abc'),
+        ('http://foo/', 'http://foo/bar%20maurice', 'http://foo/bar maurice'),
+    ],
+)
+async def test_path_basic(
+    mockserver: fixture_types.MockserverFixture,
+    simple_client,
+    mock_url,
+    request_path,
+    expected_path,
+):
+    @mockserver.aiohttp_json_handler(mock_url, prefix=True)
+    def mock(request):
+        pass
+
+    await simple_client(request_path)
+    mock_request = mock.next_call()['request']
+    assert mock_request.original_path == expected_path

--- a/tests/plugins/mockserver/test_proxy.py
+++ b/tests/plugins/mockserver/test_proxy.py
@@ -8,22 +8,21 @@ from testsuite._internal import fixture_types
 @pytest.fixture
 def simple_client(mockserver_info):
     async def client(path: str):
-        async with asyncio.timeout(10):
-            reader, writer = await asyncio.open_connection(
-                mockserver_info.host, mockserver_info.port
-            )
+        reader, writer = await asyncio.open_connection(
+            mockserver_info.host, mockserver_info.port
+        )
 
-            request = f'GET {path} HTTP/1.0\r\n' f'\r\n'
-            writer.write(request.encode())
-            await writer.drain()
+        request = f'GET {path} HTTP/1.0\r\n' f'\r\n'
+        writer.write(request.encode())
+        await writer.drain()
 
-            data = await reader.read()
-            writer.close()
-            await writer.wait_closed()
+        data = await reader.read()
+        writer.close()
+        await writer.wait_closed()
 
-            lines = data.splitlines()
-            assert len(lines) > 1
-            assert lines[0].decode('utf-8') == ('HTTP/1.0 200 OK'), data
+        lines = data.splitlines()
+        assert len(lines) > 1
+        assert lines[0].decode('utf-8') == ('HTTP/1.0 200 OK'), data
 
     return client
 

--- a/tests/plugins/mockserver/test_tracing_disabled.py
+++ b/tests/plugins/mockserver/test_tracing_disabled.py
@@ -47,7 +47,7 @@ async def test_mockserver_raises_on_unhandled_request_from_other_sources(
         tracing_enabled=False,
     )
     with mockserver.new_session() as session:
-        request = aiohttp.test_utils.make_mocked_request(
+        request = _make_mocked_request(
             'POST',
             '/arbitrary/path',
             headers=http_headers,
@@ -56,3 +56,9 @@ async def test_mockserver_raises_on_unhandled_request_from_other_sources(
         assert len(session._errors) == 1
         error = session._errors.pop()
         assert isinstance(error, exceptions.HandlerNotFoundError)
+
+
+def _make_mocked_request(*args, **kwargs):
+    request = aiohttp.test_utils.make_mocked_request(*args, **kwargs)
+    request.original_path = request.path
+    return request


### PR DESCRIPTION
Fixes backward-compatibility issue with aiohttp >= 3.8.2