### PR TITLE
RecursivePartialDict

### DIFF
--- a/tests/utils/test_matching.py
+++ b/tests/utils/test_matching.py
@@ -208,3 +208,40 @@ def test_unordered_list():
     assert [{'v': 'a'}, {'v': 'b'}] == matching.unordered_list(
         [{'v': 'b'}, {'v': 'a'}], key=lambda x: x['v']
     )
+
+
+def test_recursive_partial_dict():
+    sample = {
+        'some_key': 'some_value',
+        'some_map_like_object': [('a', 1), ('b', 2), ('c', 3)],
+        'some_dict': {
+            'wrapped_int': 10_000,
+            'wrapped_str': 'value',
+            'wrapped_dict': {
+                'inner_key': 'inner_value',
+                'inner_dict': {
+                    'other_key': 'other_value',
+                },
+            },
+        },
+    }
+
+    needle = {'some_key': 'some_value'}
+    assert sample == matching.RecursivePartialDict(**needle)
+    needle = {'some_map_like_object': [('a', 1), ('b', 2), ('c', 3)]}
+    assert sample == matching.RecursivePartialDict(**needle)
+    needle = {'some_dict': {}}
+    assert sample == matching.RecursivePartialDict(**needle)
+    needle = {'some_dict': {'wrapped_int': 10_000}}
+    assert sample == matching.RecursivePartialDict(**needle)
+    needle = {'some_dict': {'wrapped_str': 'value'}}
+    assert sample == matching.RecursivePartialDict(**needle)
+    needle = {'some_dict': {'wrapped_dict': {}}}
+    assert sample == matching.RecursivePartialDict(**needle)
+    needle = {'some_dict': {'wrapped_dict': {'inner_key': 'inner_value'}}}
+    assert sample == matching.RecursivePartialDict(**needle)
+    needle = {'some_dict': {'wrapped_dict': {'inner_dict': {}}}}
+    assert sample == matching.RecursivePartialDict(**needle)
+    
+    needle = {'some_map_like_object': {'a': 1, 'b': 2, 'c': 3}}
+    assert sample != matching.RecursivePartialDict(**needle)

--- a/tests/utils/test_matching.py
+++ b/tests/utils/test_matching.py
@@ -215,10 +215,7 @@ def test_recursive_partial_dict():
         'some_key': 'some_value',
         'some_map_like_object': [('a', 1), ('b', 2), ('c', 3)],
         'some_dict': {
-            'wrapped_int': 10_000,
-            'wrapped_str': 'value',
             'wrapped_dict': {
-                'inner_key': 'inner_value',
                 'inner_dict': {
                     'other_key': 'other_value',
                 },
@@ -228,20 +225,24 @@ def test_recursive_partial_dict():
 
     needle = {'some_key': 'some_value'}
     assert sample == matching.RecursivePartialDict(**needle)
-    needle = {'some_map_like_object': [('a', 1), ('b', 2), ('c', 3)]}
-    assert sample == matching.RecursivePartialDict(**needle)
+
     needle = {'some_dict': {}}
-    assert sample == matching.RecursivePartialDict(**needle)
-    needle = {'some_dict': {'wrapped_int': 10_000}}
-    assert sample == matching.RecursivePartialDict(**needle)
-    needle = {'some_dict': {'wrapped_str': 'value'}}
     assert sample == matching.RecursivePartialDict(**needle)
     needle = {'some_dict': {'wrapped_dict': {}}}
     assert sample == matching.RecursivePartialDict(**needle)
-    needle = {'some_dict': {'wrapped_dict': {'inner_key': 'inner_value'}}}
-    assert sample == matching.RecursivePartialDict(**needle)
     needle = {'some_dict': {'wrapped_dict': {'inner_dict': {}}}}
     assert sample == matching.RecursivePartialDict(**needle)
-    
+
+    needle = {'some_map_like_object': [('a', 1), ('b', 2), ('c', 3)]}
+    assert sample == matching.RecursivePartialDict(**needle)
     needle = {'some_map_like_object': {'a': 1, 'b': 2, 'c': 3}}
     assert sample != matching.RecursivePartialDict(**needle)
+    needle = {'some_map_like_object': [('a', 1)]}
+    assert sample != matching.RecursivePartialDict(**needle)
+
+    needle = {
+        'some_dict': {
+            'wrapped_dict': {'inner_dict': {'other_key': 'other_value'}}
+        }
+    }
+    assert sample == matching.RecursivePartialDict(**needle)

--- a/testsuite/utils/matching.py
+++ b/testsuite/utils/matching.py
@@ -296,6 +296,58 @@ class PartialDict(collections.abc.Mapping):
         return True
 
 
+class RecursivePartialDict(PartialDict):
+    """RecursivePartialDict is inherited from PartialDict.
+
+    The difference is that RecursivePartialDict applies
+    itself on all nested mapping-like objects.
+
+    It simplifies *really* nested objects comparison.
+
+    Example:
+    - instead of
+
+    ``` code-block:: python
+        assert order == matching.PartialDict(
+            items=matching.PartialDict(
+                price='100.0',
+                amoun='2',
+                courier_info=matching.PartialDict(
+                    name='Max',
+                    organization=matching.PartialDict(
+                        comission_rate='10',
+                    ),
+                ),
+            ),
+        )
+    ```
+
+    - you can write
+
+    ``` code-block:: python
+        assert order == matching.RecursivePartialDict(
+            items={
+                'price': '100.0',
+                'amount': '2',
+                'courier_info': {
+                    'name': 'Max',
+                    'organization': {'comission_rate': 10},
+                },
+            },
+        )
+    ```
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._dict = dict()
+
+        for key, value in tuple(*args) + tuple(kwargs.items()):
+            if isinstance(value, collections.abc.Mapping):
+                self._dict[key] = RecursivePartialDict(**value)
+            else:
+                self._dict[key] = value
+
+
 class UnorderedList:
     def __init__(self, sequence, key):
         self.value = sorted(sequence, key=key)

--- a/testsuite/utils/matching.py
+++ b/testsuite/utils/matching.py
@@ -312,11 +312,11 @@ class RecursivePartialDict(PartialDict):
             items=matching.PartialDict(
                 price='100.0',
                 amoun='2',
-                courier_info=matching.PartialDict(
-                    name='Max',
-                    organization=matching.PartialDict(
-                        comission_rate='10',
-                    ),
+            ),
+            courier_info=matching.PartialDict(
+                name='Max',
+                organization=matching.PartialDict(
+                    comission_rate='10',
                 ),
             ),
         )
@@ -329,10 +329,10 @@ class RecursivePartialDict(PartialDict):
             items={
                 'price': '100.0',
                 'amount': '2',
-                'courier_info': {
-                    'name': 'Max',
-                    'organization': {'comission_rate': 10},
-                },
+            },
+            courier_info={
+                'name': 'Max',
+                'organization': {'comission_rate': 10},
             },
         )
     ```


### PR DESCRIPTION
Добрый день! Увидел в либе класс `PartialDict`, и понял что порой приходится многократно использовать его рекуррентно. Для избавления от такой проблемы предлагаю рассмотреть добавление RecursivePartialDict, что автоматически применяет на всякие dict-like передаваемы объекты свой конструктор. Пример:

- Вместо подобной вложенной конструкции:
```python
assert order == matching.PartialDict(
    items=matching.PartialDict(
        price='100.0',
        amoun='2',
    ),
    courier_info=matching.PartialDict(
        name='Max',
        organization=matching.PartialDict(
            comission_rate='10',
        ),
    ),
)
```

- Теперь можно будет писать упрощенно:
```python
assert order == matching.RecursivePartialDict(
    items={
        'price': '100.0',
        'amount': '2',
    },
    courier_info={
        'name': 'Max',
        'organization': {'comission_rate': 10},
    },
)
```