### PR TITLE
feat redis: add standalone configuration

### DIFF
--- a/docs/redis.rst
+++ b/docs/redis.rst
@@ -32,6 +32,11 @@ TESTSUITE_REDIS_CLUSTER_REPLICAS
 
 Use to override number of replicas per master in redis cluster. Default is ``1``.
 
+TESTSUITE_REDIS_STANDALONE_PORT
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use to override standalone server port. Default is ``7000``.
+
 
 Fixtures
 --------
@@ -39,7 +44,7 @@ Fixtures
 redis_store
 ~~~~~~~~~~~
 
-Provide access to non cluster redis via same interface as redis.StrictRedis().
+Provide access to non cluster redis with sentinels via same interface as redis.StrictRedis().
 
 .. code-block:: python
 
@@ -76,6 +81,27 @@ Provide access to cluster redis via same interface as redis.RedisCluster().
       assert redis_cluster_store.get('somekey') == b'somedata'
 
 
+redis_standalone_store
+~~~~~~~~~~~~~~~~~~~~~~
+
+Provide access to standalone redis (no slaves or sentinels, only single master)
+via same interface as redis.StrictRedis().
+
+.. code-block:: python
+
+  import pytest
+
+  pytest_plugins = [
+      'testsuite.pytest_plugin',
+      'testsuite.databases.redis.pytest_plugin',
+  ]
+
+
+  def test_redis_basic(redis_standalone_store):
+      redis_standalone_store.set('somekey', 'somedata')
+      assert redis_standalone_store.get('somekey') == b'somedata'
+
+
 redis_cluster_nodes
 ~~~~~~~~~~~~~~~~~~~
 
@@ -86,6 +112,12 @@ redis_cluster_replicas
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Gives the number of replicas per primary node in redis cluster.
+
+
+redis_standalone_node
+~~~~~~~~~~~~~~~~~~~~~~
+
+Returns a dictionary with 'host' and 'port' values of the standalone redis.
 
 
 Marks
@@ -143,3 +175,11 @@ Specify custom per-test data for ``redis_cluster_store`` fixture
   @pytest.mark.redis_cluster_store(file='use_redis_store_file')
   def test_redis_store_file(redis_cluster_store):
       assert redis_cluster_store.get('foo') == b'store'
+
+
+
+pytest.mark.redis_standalone_store
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify custom per-test data for ``redis_standalone_store`` fixture. See above
+for a usage example.

--- a/tests/databases/redis/test_standalone.py
+++ b/tests/databases/redis/test_standalone.py
@@ -10,5 +10,5 @@ def test_standalone_config(redis_standalone_store: redisdb.StrictRedis):
 
 
 def test_standalone_rw(redis_standalone_store: redis.RedisCluster):
-    assert redis_standalone_store.set('foo', b'bar')
-    assert redis_standalone_store.get('foo') == b'bar'
+    assert redis_standalone_store.set('foo_standalone', b'bar')
+    assert redis_standalone_store.get('foo_standalone') == b'bar'

--- a/tests/databases/redis/test_standalone.py
+++ b/tests/databases/redis/test_standalone.py
@@ -4,11 +4,6 @@ import redis
 from testsuite.databases.redis import service
 
 
-def test_standalone_config(redis_standalone_store: redis.StrictRedis):
-    masters = redis_standalone_store.sentinel_masters()
-    assert len(masters) == 1
-
-
 def test_standalone_rw(redis_standalone_store: redis.RedisCluster):
     assert redis_standalone_store.set('foo_standalone', b'bar')
     assert redis_standalone_store.get('foo_standalone') == b'bar'

--- a/tests/databases/redis/test_standalone.py
+++ b/tests/databases/redis/test_standalone.py
@@ -4,7 +4,7 @@ import redis
 from testsuite.databases.redis import service
 
 
-def test_standalone_config(redis_standalone_store: redisdb.StrictRedis):
+def test_standalone_config(redis_standalone_store: redis.StrictRedis):
     masters = redis_standalone_store.sentinel_masters()
     assert len(masters) == 1
 

--- a/tests/databases/redis/test_standalone.py
+++ b/tests/databases/redis/test_standalone.py
@@ -1,0 +1,14 @@
+import pytest
+import redis
+
+from testsuite.databases.redis import service
+
+
+def test_standalone_config(redis_standalone_store: redisdb.StrictRedis):
+    masters = redis_standalone_store.sentinel_masters()
+    assert len(masters) == 1
+
+
+def test_standalone_rw(redis_standalone_store: redis.RedisCluster):
+    assert redis_standalone_store.set('foo', b'bar')
+    assert redis_standalone_store.get('foo') == b'bar'

--- a/tests/testpoint/test_fixture.py
+++ b/tests/testpoint/test_fixture.py
@@ -87,8 +87,7 @@ async def test_not_handled(
 
 def test_deletion_by_name(testpoint):
     @testpoint('foo')
-    def foo_point(data):
-        ...
+    def foo_point(data): ...
 
     assert 'foo' in testpoint
     del testpoint['foo']
@@ -101,8 +100,7 @@ def test_deletion_by_name(testpoint):
 
 def test_deletion_func(testpoint):
     @testpoint('foo')
-    def foo_point(data):
-        ...
+    def foo_point(data): ...
 
     del testpoint[foo_point]
     assert 'foo' not in testpoint
@@ -112,8 +110,7 @@ def test_deletion_func(testpoint):
 
     @testpoint('foo')  # type: ignore[no-redef]
     @testpoint('bar')
-    def foo_point(data):
-        ...
+    def foo_point(data): ...
 
     del testpoint[foo_point]
     assert 'foo' not in testpoint

--- a/tests/testpoint/test_fixture.py
+++ b/tests/testpoint/test_fixture.py
@@ -87,7 +87,8 @@ async def test_not_handled(
 
 def test_deletion_by_name(testpoint):
     @testpoint('foo')
-    def foo_point(data): ...
+    def foo_point(data):
+        ...
 
     assert 'foo' in testpoint
     del testpoint['foo']
@@ -100,7 +101,8 @@ def test_deletion_by_name(testpoint):
 
 def test_deletion_func(testpoint):
     @testpoint('foo')
-    def foo_point(data): ...
+    def foo_point(data):
+        ...
 
     del testpoint[foo_point]
     assert 'foo' not in testpoint
@@ -110,7 +112,8 @@ def test_deletion_func(testpoint):
 
     @testpoint('foo')  # type: ignore[no-redef]
     @testpoint('bar')
-    def foo_point(data): ...
+    def foo_point(data):
+        ...
 
     del testpoint[foo_point]
     assert 'foo' not in testpoint

--- a/testsuite/databases/redis/genredis.py
+++ b/testsuite/databases/redis/genredis.py
@@ -256,10 +256,10 @@ def generate_standalone_redis_config(
     port: int,
 ) -> None:
     protected_mode_no = ''
-    if genredis.redis_version() >= (3, 2, 0):
+    if redis_version() >= (3, 2, 0):
         protected_mode_no = 'protected-mode no'
 
-    input_file = _redis_config_directory() / genredis.MASTER_TPL_FILENAME
+    input_file = _redis_config_directory() / MASTER_TPL_FILENAME
     output_file = _construct_output_filename(
         output_path,
         MASTER_TPL_FILENAME,
@@ -270,8 +270,8 @@ def generate_standalone_redis_config(
         input_file,
         output_file,
         protected_mode_no,
-        settings.host,
-        settings.port,
+        host,
+        port,
     )
 
 

--- a/testsuite/databases/redis/genredis.py
+++ b/testsuite/databases/redis/genredis.py
@@ -250,6 +250,31 @@ def generate_cluster_redis_configs(
     )
 
 
+def generate_standalone_redis_config(
+    output_path: pathlib.Path,
+    host: str,
+    port: int,
+) -> None:
+    protected_mode_no = ''
+    if genredis.redis_version() >= (3, 2, 0):
+        protected_mode_no = 'protected-mode no'
+
+    input_file = _redis_config_directory() / genredis.MASTER_TPL_FILENAME
+    output_file = _construct_output_filename(
+        output_path,
+        MASTER_TPL_FILENAME,
+        0,
+    )
+
+    _generate_redis_config(
+        input_file,
+        output_file,
+        protected_mode_no,
+        settings.host,
+        settings.port,
+    )
+
+
 def generate_redis_configs(
     output_path: pathlib.Path,
     host: str,

--- a/testsuite/databases/redis/pytest_plugin.py
+++ b/testsuite/databases/redis/pytest_plugin.py
@@ -37,7 +37,9 @@ def pytest_configure(config):
 def pytest_service_register(register_service):
     register_service('redis', service.create_redis_service)
     register_service('redis-cluster', service.create_cluster_redis_service)
-    register_service('redis-standalone', service.create_standalone_redis_service)
+    register_service(
+        'redis-standalone', service.create_standalone_redis_service
+    )
 
 
 @pytest.fixture(scope='session')
@@ -52,9 +54,7 @@ def redis_service(
 
 @pytest.fixture(scope='session')
 def redis_cluster_service(
-    pytestconfig,
-    ensure_service_started,
-    _redis_cluster_service_settings,
+    pytestconfig, ensure_service_started, _redis_cluster_service_settings
 ):
     if not pytestconfig.option.no_redis and not pytestconfig.option.redis_host:
         ensure_service_started(
@@ -191,12 +191,10 @@ def redis_cluster_nodes(_redis_cluster_service_settings):
 
 @pytest.fixture(scope='session')
 def redis_standalone_node(_redis_standalone_service_settings):
-    return [
-        {
-            'host': _redis_standalone_service_settings.host,
-            'port': _redis_standalone_service_settings.port,
-        },
-    ]
+    return {
+        'host': _redis_standalone_service_settings.host,
+        'port': _redis_standalone_service_settings.port,
+    }
 
 
 @pytest.fixture(scope='session')
@@ -264,9 +262,7 @@ def _redis_cluster_store(
 
 @pytest.fixture
 def redis_standalone_store(
-    pytestconfig,
-    redis_standalone_service,
-    redis_standalone_node
+    pytestconfig, redis_standalone_service, redis_standalone_node
 ):
     if pytestconfig.option.no_redis:
         yield

--- a/testsuite/databases/redis/pytest_plugin.py
+++ b/testsuite/databases/redis/pytest_plugin.py
@@ -37,6 +37,7 @@ def pytest_configure(config):
 def pytest_service_register(register_service):
     register_service('redis', service.create_redis_service)
     register_service('redis-cluster', service.create_cluster_redis_service)
+    register_service('redis-standalone', service.create_standalone_redis_service)
 
 
 @pytest.fixture(scope='session')
@@ -58,6 +59,17 @@ def redis_cluster_service(
     if not pytestconfig.option.no_redis and not pytestconfig.option.redis_host:
         ensure_service_started(
             'redis-cluster', settings=_redis_cluster_service_settings
+        )
+
+
+@pytest.fixture(scope='session')
+async def redis_standalone_service(
+    ensure_service_started,
+    _redis_standalone_service_settings
+):
+    if not pytestconfig.option.no_redis and not pytestconfig.option.redis_host:
+        ensure_service_started(
+            'redis-standalone', settings=_redis_standalone_service_settings
         )
 
 
@@ -177,6 +189,16 @@ def redis_cluster_nodes(_redis_cluster_service_settings):
 
 
 @pytest.fixture(scope='session')
+def redis_standalone_node(_redis_standalone_service_settings):
+    return [
+        {
+            'host': _redis_standalone_service_settings.host,
+            'port': _redis_standalone_service_settings.port,
+        },
+    ]
+
+
+@pytest.fixture(scope='session')
 def redis_cluster_replicas(_redis_cluster_service_settings):
     return _redis_cluster_service_settings.cluster_replicas
 
@@ -189,6 +211,11 @@ def _redis_service_settings():
 @pytest.fixture(scope='session')
 def _redis_cluster_service_settings():
     return service.get_cluster_service_settings()
+
+
+@pytest.fixture(scope='session')
+def _redis_standalone_service_settings():
+    return service.get_standalone_service_settings()
 
 
 def _json_object_hook(dct):
@@ -232,6 +259,27 @@ def _redis_cluster_store(
     )
 
     yield redis_db
+
+
+@pytest.fixture
+def redis_standalone_store(
+    pytestconfig,
+    redis_standalone_service,
+    redis_standalone_node
+):
+    if pytestconfig.option.no_redis:
+        yield
+        return
+
+    redis_db = redisdb.StrictRedis(
+        host=redis_standalone_node['host'],
+        port=redis_standalone_node['port'],
+    )
+
+    try:
+        yield redis_db
+    finally:
+        redis_db.flushall()
 
 
 @pytest.fixture

--- a/testsuite/databases/redis/pytest_plugin.py
+++ b/testsuite/databases/redis/pytest_plugin.py
@@ -64,9 +64,7 @@ def redis_cluster_service(
 
 @pytest.fixture(scope='session')
 async def redis_standalone_service(
-    pytestconfig,
-    ensure_service_started,
-    _redis_standalone_service_settings
+    pytestconfig, ensure_service_started, _redis_standalone_service_settings
 ):
     if not pytestconfig.option.no_redis and not pytestconfig.option.redis_host:
         ensure_service_started(

--- a/testsuite/databases/redis/pytest_plugin.py
+++ b/testsuite/databases/redis/pytest_plugin.py
@@ -32,6 +32,10 @@ def pytest_configure(config):
         'markers',
         'redis_cluster_store: per-test redis cluster initialization',
     )
+    config.addinivalue_line(
+        'markers',
+        'redis_standalone_store: per-test standalone redis initialization',
+    )
 
 
 def pytest_service_register(register_service):

--- a/testsuite/databases/redis/pytest_plugin.py
+++ b/testsuite/databases/redis/pytest_plugin.py
@@ -64,6 +64,7 @@ def redis_cluster_service(
 
 @pytest.fixture(scope='session')
 async def redis_standalone_service(
+    pytestconfig,
     ensure_service_started,
     _redis_standalone_service_settings
 ):

--- a/testsuite/databases/redis/scripts/service-standalone-redis
+++ b/testsuite/databases/redis/scripts/service-standalone-redis
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+. "$TESTSUITE_LIB_UTILS"
+
+if [ "x$REDIS_CONFIG_FILE" = "x" ]; then
+    die "REDIS_CONFIG_FILE must be set"
+fi
+
+REDIS_SERVER=$(which redis-server)
+REDIS_ROLE="standalone"
+if [ "x$REDIS_SERVER" = "x" ]; then
+    die "No redis-server binary found"
+fi
+
+start() {
+
+    echo "Starting redis ($REDIS_ROLE) with config '$REDIS_CONFIG_FILE'..."
+    pidfile="$(get_pidfile $REDIS_ROLE)"
+    $REDIS_SERVER $REDIS_CONFIG_FILE \
+                    --pidfile $pidfile || {
+        die "Failed to start redis ($REDIS_ROLE) server"
+    }
+}
+
+stop() {
+    pidfile="$(get_pidfile $REDIS_ROLE)"
+    stop_daemon $REDIS_SERVER $pidfile
+}
+
+script_main "$@"
+

--- a/testsuite/databases/redis/scripts/service-standalone-redis
+++ b/testsuite/databases/redis/scripts/service-standalone-redis
@@ -2,8 +2,8 @@
 
 . "$TESTSUITE_LIB_UTILS"
 
-if [ "x$REDIS_CONFIG_FILE" = "x" ]; then
-    die "REDIS_CONFIG_FILE must be set"
+if [ "x$REDIS_CONFIGS_DIR" = "x" ]; then
+    die "REDIS_CONFIGS_DIR must be set"
 fi
 
 REDIS_SERVER=$(which redis-server)
@@ -14,10 +14,9 @@ fi
 
 start() {
 
-    echo "Starting redis ($REDIS_ROLE) with config '$REDIS_CONFIG_FILE'..."
+    echo "Starting redis ($REDIS_ROLE) with config '$REDIS_CONFIGS_DIR/redis_master0.conf'..."
     pidfile="$(get_pidfile $REDIS_ROLE)"
-    $REDIS_SERVER $REDIS_CONFIG_FILE \
-                    --pidfile $pidfile || {
+    $REDIS_SERVER $REDIS_CONFIGS_DIR/redis_master0.conf --pidfile $pidfile || {
         die "Failed to start redis ($REDIS_ROLE) server"
     }
 }

--- a/testsuite/databases/redis/service.py
+++ b/testsuite/databases/redis/service.py
@@ -108,7 +108,7 @@ def get_cluster_service_settings():
 
 def get_standalone_service_settings():
     return StandaloneServiceSettings(
-        host=service._get_hostname(),
+        host=_get_hostname(),
         port=utils.getenv_int(
             key='TESTSUITE_REDIS_STANDALONE_PORT',
             default=DEFAULT_STANDALONE_PORT,
@@ -211,23 +211,14 @@ def create_standalone_redis_service(
     if settings is None:
         settings = get_standalone_service_settings()
     configs_dir = pathlib.Path(working_dir).joinpath('configs')
-    input_file = (
-        genredis._redis_config_directory() / genredis.MASTER_TPL_FILENAME
-    )
-    output_file = configs_dir.joinpath(f"{service_name}.conf")
 
     def prestart_hook():
         configs_dir.mkdir(parents=True, exist_ok=True)
-        protected_mode_no = ''
-        if genredis.redis_version() >= (3, 2, 0):
-            protected_mode_no = 'protected-mode no'
-
-        genredis._generate_redis_config(
-            input_file,
-            output_file,
-            protected_mode_no,
-            settings.host,
-            settings.port,
+        settings.validate()
+        genredis.generate_standalone_redis_config(
+            output_path=configs_dir,
+            host=settings.host,
+            port=settings.port,
         )
 
     return service.ScriptService(

--- a/testsuite/databases/redis/service.py
+++ b/testsuite/databases/redis/service.py
@@ -227,7 +227,7 @@ def create_standalone_redis_service(
             output_file,
             protected_mode_no,
             settings.host,
-            settings.port
+            settings.port,
         )
 
     return service.ScriptService(

--- a/testsuite/databases/redis/service.py
+++ b/testsuite/databases/redis/service.py
@@ -213,8 +213,6 @@ def create_standalone_redis_service(
     input_file = genredis._redis_config_directory() / genredis.MASTER_TPL_FILENAME
     output_file = configs_dir.joinpath(f"{service_name}.conf")
 
-    logging.debug(f"Config file for redis standalone is '{output_file}'")
-
     def prestart_hook():
         configs_dir.mkdir(parents=True, exist_ok=True)
         protected_mode_no = ''
@@ -225,7 +223,7 @@ def create_standalone_redis_service(
             input_file, output_file, protected_mode_no, settings.host, settings.port
         )
 
-    return ScriptService(
+    return service.ScriptService(
         service_name=service_name,
         script_path=str(STANDALONE_SERVICE_SCRIPT_PATH),
         working_dir=working_dir,

--- a/testsuite/databases/redis/service.py
+++ b/testsuite/databases/redis/service.py
@@ -14,12 +14,16 @@ DEFAULT_SENTINEL_PORT = 26379
 DEFAULT_SLAVE_PORTS = (16380, 16390, 16381)
 DEFAULT_CLUSTER_PORTS = (17380, 17381, 17382, 17383, 17384, 17385)
 DEFAULT_CLUSTER_REPLICAS = 1
+DEFAULT_STANDALONE_PORT = 7000
 
 SERVICE_SCRIPT_PATH = pathlib.Path(__file__).parent.joinpath(
     'scripts/service-redis',
 )
 CLUSTER_SERVICE_SCRIPT_PATH = pathlib.Path(__file__).parent.joinpath(
     'scripts/service-cluster-redis',
+)
+STANDALONE_SERVICE_SCRIPT_PATH = pathlib.Path(__file__).parent.joinpath(
+    'scripts/service-standalone-redis',
 )
 
 
@@ -65,6 +69,11 @@ class ClusterServiceSettings(typing.NamedTuple):
             )
 
 
+class StandaloneServiceSettings(typing.NamedTuple):
+    host: str
+    port: int
+
+
 def get_service_settings():
     return ServiceSettings(
         host=_get_hostname(),
@@ -96,6 +105,15 @@ def get_cluster_service_settings():
         ),
     )
 
+
+def get_standalone_service_settings():
+    return StandaloneServiceSettings(
+        host=service._get_hostname(),
+        port=utils.getenv_int(
+            key='TESTSUITE_REDIS_STANDALONE_PORT',
+            default=DEFAULT_STANDALONE_PORT,
+        )
+    )
 
 def create_redis_service(
     service_name,
@@ -179,6 +197,44 @@ def create_cluster_redis_service(
         },
         check_host=settings.host,
         check_ports=check_ports,
+        prestart_hook=prestart_hook,
+    )
+
+
+def create_standalone_redis_service(
+    service_name,
+    working_dir,
+    settings: typing.Optional[StandaloneServiceSettings] = None,
+    env=None,
+):
+    if settings is None:
+        settings = get_standalone_service_settings()
+    configs_dir = pathlib.Path(working_dir).joinpath('configs')
+    input_file = genredis._redis_config_directory() / genredis.MASTER_TPL_FILENAME
+    output_file = configs_dir.joinpath(f"{service_name}.conf")
+
+    logging.debug(f"Config file for redis standalone is '{output_file}'")
+
+    def prestart_hook():
+        configs_dir.mkdir(parents=True, exist_ok=True)
+        protected_mode_no = ''
+        if genredis.redis_version() >= (3, 2, 0):
+            protected_mode_no = 'protected-mode no'
+
+        genredis._generate_redis_config(
+            input_file, output_file, protected_mode_no, settings.host, settings.port
+        )
+
+    return ScriptService(
+        service_name=service_name,
+        script_path=str(STANDALONE_SERVICE_SCRIPT_PATH),
+        working_dir=working_dir,
+        environment={
+            'REDIS_CONFIG_FILE': output_file,
+            **(env or {}),
+        },
+        check_host=settings.host,
+        check_ports=[settings.port],
         prestart_hook=prestart_hook,
     )
 

--- a/testsuite/databases/redis/service.py
+++ b/testsuite/databases/redis/service.py
@@ -214,7 +214,6 @@ def create_standalone_redis_service(
 
     def prestart_hook():
         configs_dir.mkdir(parents=True, exist_ok=True)
-        settings.validate()
         genredis.generate_standalone_redis_config(
             output_path=configs_dir,
             host=settings.host,

--- a/testsuite/databases/redis/service.py
+++ b/testsuite/databases/redis/service.py
@@ -226,7 +226,7 @@ def create_standalone_redis_service(
         script_path=str(STANDALONE_SERVICE_SCRIPT_PATH),
         working_dir=working_dir,
         environment={
-            'REDIS_CONFIG_FILE': output_file,
+            'REDIS_CONFIGS_DIR': str(configs_dir),
             **(env or {}),
         },
         check_host=settings.host,

--- a/testsuite/databases/redis/service.py
+++ b/testsuite/databases/redis/service.py
@@ -112,8 +112,9 @@ def get_standalone_service_settings():
         port=utils.getenv_int(
             key='TESTSUITE_REDIS_STANDALONE_PORT',
             default=DEFAULT_STANDALONE_PORT,
-        )
+        ),
     )
+
 
 def create_redis_service(
     service_name,
@@ -210,7 +211,9 @@ def create_standalone_redis_service(
     if settings is None:
         settings = get_standalone_service_settings()
     configs_dir = pathlib.Path(working_dir).joinpath('configs')
-    input_file = genredis._redis_config_directory() / genredis.MASTER_TPL_FILENAME
+    input_file = (
+        genredis._redis_config_directory() / genredis.MASTER_TPL_FILENAME
+    )
     output_file = configs_dir.joinpath(f"{service_name}.conf")
 
     def prestart_hook():
@@ -220,7 +223,11 @@ def create_standalone_redis_service(
             protected_mode_no = 'protected-mode no'
 
         genredis._generate_redis_config(
-            input_file, output_file, protected_mode_no, settings.host, settings.port
+            input_file,
+            output_file,
+            protected_mode_no,
+            settings.host,
+            settings.port
         )
 
     return service.ScriptService(


### PR DESCRIPTION
Added pytest redis_standalone to run single redis instance. Plugin uses the same approach and configs as in ya testsuite plugins to run redis and redis cluster: https://github.com/yandex/yandex-taxi-testsuite/tree/develop/testsuite/databases/redis

Cherry-pick some of the changes from https://github.com/userver-framework/userver/pull/822 and move them into testsuite

Co-authored-by: Aleksey Ignatiev <iae.ignatev@gmail.com>