### PR TITLE
feat redis: use CLUSTER NODES and CLUSTER SLOTS information to wait for cluster startup

### DIFF
--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -18,3 +18,7 @@ def test_cluster_config(
 def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
     assert redis_cluster_store.set('foo_cluster', b'bar')
     assert redis_cluster_store.get('foo_cluster') == b'bar'
+
+
+def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
+    assert redis_cluster_store.get_replicas(), "No replicas in cluster"

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -32,15 +32,10 @@ def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
 
 
 def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
-    cluster_nodes = redis_cluster_store.cluster_nodes()
+    assert redis_cluster_store.get_replicas(), 'No replicas'
 
-    assert redis_cluster_store.get_replicas(), (
-        f'No replicas. {cluster_nodes}. '
-        f'redis_cluster_store: {redis_cluster_store.nodes_manager.nodes_cache}'
-    )
+    primary = redis_cluster_store.get_node_from_key('key', replica=False)
+    assert primary, 'No primary for key'
 
-    primary = redis_cluster_store.get_node_from_key(f'key', replica=False)
-    assert primary, f'No primary for node. Nodes: {cluster_nodes}'
-
-    replica = redis_cluster_store.get_node_from_key(f'key', replica=True)
-    assert replica, f'No replica for node. Nodes: {cluster_nodes}'
+    replica = redis_cluster_store.get_node_from_key('key', replica=True)
+    assert replica, 'No replica for key'

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -1,5 +1,3 @@
-import platform
-
 import pytest
 import redis
 
@@ -33,10 +31,6 @@ def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
     assert redis_cluster_store.get('foo_cluster') == b'bar'
 
 
-@pytest.mark.skipif(
-    platform.system() == 'Darwin',
-    reason='TODO: get_replicas() does not work on MacOS',
-)
 def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
     cluster_nodes = redis_cluster_store.cluster_nodes()
 

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -7,12 +7,21 @@ from testsuite.databases.redis import service
 def test_cluster_config(
     redis_cluster_store: redis.RedisCluster,
     _redis_cluster_service_settings: service.ClusterServiceSettings,
+    redis_cluster_replicas: int,
 ):
     cluster_nodes = redis_cluster_store.cluster_nodes()
 
+    replicas = 0
+    masters = 0
     for node, info in cluster_nodes.items():
         port = int(node.rsplit(':', maxsplit=1)[-1])
         assert port in _redis_cluster_service_settings.cluster_ports
+        if 'slave' in info or 'replica' in info:
+            replicas += 1
+        else:
+            masters += 1
+
+    assert replicas == masters * redis_cluster_replicas
 
 
 def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
@@ -23,7 +32,10 @@ def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
 def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
     cluster_nodes = redis_cluster_store.cluster_nodes()
 
-    assert redis_cluster_store.get_replicas(), f'No replicas. {cluster_nodes}'
+    assert redis_cluster_store.get_replicas(), (
+        f'No replicas. {cluster_nodes}. '
+        f'redis_cluster_store: {redis_cluster_store.nodes_manager.nodes_cache}'
+    )
 
     primary = redis_cluster_store.get_node_from_key(f'key', replica=False)
     assert primary, f'No primary for node. Nodes: {cluster_nodes}'

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -16,7 +16,8 @@ def test_cluster_config(
     for node, info in cluster_nodes.items():
         port = int(node.rsplit(':', maxsplit=1)[-1])
         assert port in _redis_cluster_service_settings.cluster_ports
-        if 'slave' in info or 'replica' in info:
+        info_string = str(info)
+        if 'slave' in info_string or 'replica' in info_string:
             replicas += 1
         else:
             masters += 1

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -21,8 +21,8 @@ def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
 
 
 def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
-    # redis_cluster_store.get_replicas() does not work on MacOS.
-    # Using a more generic `get_node_from_key` approach:
+    assert redis_cluster_store.get_replicas(), 'No replicas in cluster'
+
     primary = redis_cluster_store.get_node_from_key(f'key', replica=False)
     assert primary, 'No primary for node'
 

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -21,4 +21,10 @@ def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
 
 
 def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
-    assert redis_cluster_store.get_replicas(), 'No replicas in cluster'
+    # redis_cluster_store.get_replicas() does not work on MacOS.
+    # Using a more generic `get_node_from_key` approach:
+    primary = redis_cluster_store.get_node_from_key(f'key', replica=False)
+    assert primary, 'No primary for node'
+
+    replica = redis_cluster_store.get_node_from_key(f'key', replica=True)
+    assert replica, 'No replica for node'

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -21,4 +21,4 @@ def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
 
 
 def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
-    assert redis_cluster_store.get_replicas(), "No replicas in cluster"
+    assert redis_cluster_store.get_replicas(), 'No replicas in cluster'

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -1,3 +1,5 @@
+import platform
+
 import pytest
 import redis
 
@@ -16,8 +18,9 @@ def test_cluster_config(
     for node, info in cluster_nodes.items():
         port = int(node.rsplit(':', maxsplit=1)[-1])
         assert port in _redis_cluster_service_settings.cluster_ports
-        info_string = str(info)
-        if 'slave' in info_string or 'replica' in info_string:
+
+        flags_string = str(info['flags'])
+        if 'slave' in flags_string or 'replica' in flags_string:
             replicas += 1
         else:
             masters += 1
@@ -30,6 +33,10 @@ def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
     assert redis_cluster_store.get('foo_cluster') == b'bar'
 
 
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason='TODO: get_replicas() does not work on MacOS',
+)
 def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
     cluster_nodes = redis_cluster_store.cluster_nodes()
 

--- a/tests/databases/redis/test_cluster.py
+++ b/tests/databases/redis/test_cluster.py
@@ -21,10 +21,12 @@ def test_cluster_rw(redis_cluster_store: redis.RedisCluster):
 
 
 def test_cluster_replicas(redis_cluster_store: redis.RedisCluster):
-    assert redis_cluster_store.get_replicas(), 'No replicas in cluster'
+    cluster_nodes = redis_cluster_store.cluster_nodes()
+
+    assert redis_cluster_store.get_replicas(), f'No replicas. {cluster_nodes}'
 
     primary = redis_cluster_store.get_node_from_key(f'key', replica=False)
-    assert primary, 'No primary for node'
+    assert primary, f'No primary for node. Nodes: {cluster_nodes}'
 
     replica = redis_cluster_store.get_node_from_key(f'key', replica=True)
-    assert replica, 'No replica for node'
+    assert replica, f'No replica for node. Nodes: {cluster_nodes}'

--- a/testsuite/databases/redis/pytest_plugin.py
+++ b/testsuite/databases/redis/pytest_plugin.py
@@ -255,9 +255,10 @@ def _redis_cluster_store(
         return
 
     redis_db = redisdb.RedisCluster(  # type: ignore[abstract]
-        host=redis_cluster_nodes[0]['host'],
-        port=redis_cluster_nodes[0]['port'],
-        decode_responses=True,  # required for Python3
+        startup_nodes=[
+            redisdb.cluster.ClusterNode(x['host'], x['port'])
+            for x in redis_cluster_nodes
+        ],
     )
 
     yield redis_db

--- a/testsuite/databases/redis/pytest_plugin.py
+++ b/testsuite/databases/redis/pytest_plugin.py
@@ -255,10 +255,8 @@ def _redis_cluster_store(
         return
 
     redis_db = redisdb.RedisCluster(  # type: ignore[abstract]
-        startup_nodes=[
-            redisdb.cluster.ClusterNode(x['host'], x['port'])
-            for x in redis_cluster_nodes
-        ],
+        host=redis_cluster_nodes[0]['host'],
+        port=redis_cluster_nodes[0]['port'],
     )
 
     yield redis_db

--- a/testsuite/databases/redis/pytest_plugin.py
+++ b/testsuite/databases/redis/pytest_plugin.py
@@ -257,6 +257,7 @@ def _redis_cluster_store(
     redis_db = redisdb.RedisCluster(  # type: ignore[abstract]
         host=redis_cluster_nodes[0]['host'],
         port=redis_cluster_nodes[0]['port'],
+        decode_responses=True,  # required for Python3
     )
 
     yield redis_db

--- a/testsuite/databases/redis/scripts/service-cluster-redis
+++ b/testsuite/databases/redis/scripts/service-cluster-redis
@@ -43,17 +43,14 @@ wait_for_redis_nodes_election() {
             CURRENT_REPLICAS_COUNT=$(echo "$CURRENT_NODES_REPONSE" | grep 'slave\|replica' | wc -l)
             EXPECTED_REPLICAS_COUNT=$(expr $CURRENT_MASTERS_COUNT \* $REDIS_CLUSTER_REPLICAS)
             if [ "$EXPECTED_REPLICAS_COUNT" -ne "$CURRENT_REPLICAS_COUNT" ]; then
-                echo "!!!!!!!!!!!!! BREAK '$EXPECTED_REPLICAS_COUNT' != '$CURRENT_REPLICAS_COUNT'"
                 break
             fi
         done
 
         if [ "$EXPECTED_REPLICAS_COUNT" -eq "$CURRENT_REPLICAS_COUNT" ]; then
-            echo "!!!!!!!!!!!!! RETURN '$EXPECTED_REPLICAS_COUNT' == '$CURRENT_REPLICAS_COUNT'"
-            exit 42
+            return
         fi
 
-        echo "!!!!!!!!!!!!! SLEEP '$EXPECTED_REPLICAS_COUNT' ? '$CURRENT_REPLICAS_COUNT'"
         sleep 1
     done
 

--- a/testsuite/databases/redis/scripts/service-cluster-redis
+++ b/testsuite/databases/redis/scripts/service-cluster-redis
@@ -43,14 +43,17 @@ wait_for_redis_nodes_election() {
             CURRENT_REPLICAS_COUNT=$(echo "$CURRENT_NODES_REPONSE" | grep 'slave\|replica' | wc -l)
             EXPECTED_REPLICAS_COUNT=$(expr $CURRENT_MASTERS_COUNT \* $REDIS_CLUSTER_REPLICAS)
             if [ "$EXPECTED_REPLICAS_COUNT" -ne "$CURRENT_REPLICAS_COUNT" ]; then
+                echo "!!!!!!!!!!!!! BREAK '$EXPECTED_REPLICAS_COUNT' != '$CURRENT_REPLICAS_COUNT'"
                 break
             fi
         done
 
         if [ "$EXPECTED_REPLICAS_COUNT" -eq "$CURRENT_REPLICAS_COUNT" ]; then
+            echo "!!!!!!!!!!!!! RETURN '$EXPECTED_REPLICAS_COUNT' == '$CURRENT_REPLICAS_COUNT'"
             return
         fi
 
+        echo "!!!!!!!!!!!!! SLEEP '$EXPECTED_REPLICAS_COUNT' ? '$CURRENT_REPLICAS_COUNT'"
         sleep 1
     done
 

--- a/testsuite/databases/redis/scripts/service-cluster-redis
+++ b/testsuite/databases/redis/scripts/service-cluster-redis
@@ -50,7 +50,7 @@ wait_for_redis_nodes_election() {
 
         if [ "$EXPECTED_REPLICAS_COUNT" -eq "$CURRENT_REPLICAS_COUNT" ]; then
             echo "!!!!!!!!!!!!! RETURN '$EXPECTED_REPLICAS_COUNT' == '$CURRENT_REPLICAS_COUNT'"
-            return
+            exit 42
         fi
 
         echo "!!!!!!!!!!!!! SLEEP '$EXPECTED_REPLICAS_COUNT' ? '$CURRENT_REPLICAS_COUNT'"

--- a/testsuite/databases/redis/scripts/service-cluster-redis
+++ b/testsuite/databases/redis/scripts/service-cluster-redis
@@ -42,12 +42,12 @@ wait_for_redis_nodes_election() {
             CURRENT_MASTERS_COUNT=$(echo "$CURRENT_NODES_REPONSE" | grep 'master' | wc -l)
             CURRENT_REPLICAS_COUNT=$(echo "$CURRENT_NODES_REPONSE" | grep 'slave\|replica' | wc -l)
             EXPECTED_REPLICAS_COUNT=$(expr $CURRENT_MASTERS_COUNT \* $REDIS_CLUSTER_REPLICAS)
-            if [ "x$EXPECTED_REPLICAS_COUNT" != "x$CURRENT_REPLICAS_COUNT" ]; then
+            if [ $EXPECTED_REPLICAS_COUNT -ne $CURRENT_REPLICAS_COUNT ]; then
                 break
             fi
         done
 
-        if [ "x$EXPECTED_REPLICAS_COUNT" = "x$CURRENT_REPLICAS_COUNT" ]; then
+        if [ $EXPECTED_REPLICAS_COUNT -eq $CURRENT_REPLICAS_COUNT ]; then
             return
         fi
 

--- a/testsuite/databases/redis/scripts/service-cluster-redis
+++ b/testsuite/databases/redis/scripts/service-cluster-redis
@@ -31,7 +31,7 @@ wait_redis_ready() {
     die "Failed to connect to redis instance on port $HOST:$PORT"
 }
 
-wait_for_redis_nodes_election() {
+wait_redis_nodes_election() {
     local CURRENT_REPLICAS_COUNT=0
     local EXPECTED_REPLICAS_COUNT=999
     local CURRENT_NODES_REPONSE=
@@ -56,6 +56,64 @@ wait_for_redis_nodes_election() {
 
     die "Failed to start redis cluster in ${REDIS_SLEEP_WORKAROUND_SECONDS} seconds. \
         Try increasing the REDIS_SLEEP_WORKAROUND_SECONDS."
+}
+
+check_cluster_slots_response_has_all_the_ports() {
+    local PORT=$1
+    local CHECK_STATUS='BAD'
+    local MATCHED_HOST='NO'
+    local CURRENT_REDIS_SLOTS=''
+
+    CURRENT_REDIS_SLOTS=$($REDIS_CLI -h $REDIS_HOST -p $PORT CLUSTER SLOTS)
+    for CLUSTER_NODE_PORT in ${REDIS_CLUSTER_PORTS}; do
+        CHECK_STATUS='BAD'
+
+        MATCHED_HOST='NO'
+        for LINE in ${CURRENT_REDIS_SLOTS}; do
+            if [ "x$LINE" = "x$REDIS_HOST" ]; then
+                MATCHED_HOST='YES'
+            elif [ "x$MATCHED_HOST" = "xYES" ] && [ "x$LINE" = "x$CLUSTER_NODE_PORT" ]; then
+                MATCHED_HOST='NO'
+                CHECK_STATUS='OK'
+                break
+            else
+                MATCHED_HOST='NO'
+            fi
+        done
+
+        if [ "x$CHECK_STATUS" = "xBAD" ]; then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+wait_redis_nodes_slots_update() {
+    local CHECK_STATUS='BAD'
+
+    for i in $(seq 1 ${REDIS_SLEEP_WORKAROUND_SECONDS}); do
+        CHECK_STATUS='OK'
+        for PORT in ${REDIS_CLUSTER_PORTS}; do
+            if check_cluster_slots_response_has_all_the_ports $PORT; then
+                continue
+            else
+                CHECK_STATUS='BAD'
+                break
+            fi
+        done
+
+        if [ "x$CHECK_STATUS" = "xOK" ]; then
+            return
+        fi
+
+        sleep 1
+    done
+
+
+    die "Failed to start redis cluster in ${REDIS_SLEEP_WORKAROUND_SECONDS} seconds \
+        due to CLUSTER SLOTS incomplete output. Try increasing the \
+        REDIS_SLEEP_WORKAROUND_SECONDS."
 }
 
 start() {
@@ -94,7 +152,8 @@ start() {
         --cluster-yes || \
         die "Failed to create a redis cluster"
 
-    wait_for_redis_nodes_election
+    wait_redis_nodes_election
+    wait_redis_nodes_slots_update
 
     echo "Created redis cluster ..."
 }

--- a/testsuite/databases/redis/scripts/service-cluster-redis
+++ b/testsuite/databases/redis/scripts/service-cluster-redis
@@ -10,7 +10,7 @@
 
 REDIS_DATADIR="$REDIS_TMPDIR/data"
 REDIS_LOGSDIR="$REDIS_TMPDIR/logs"
-REDIS_SLEEP_WORKAROUND_SECONDS=${REDIS_SLEEP_WORKAROUND_SECONDS:=3}
+REDIS_SLEEP_WORKAROUND_SECONDS=${REDIS_SLEEP_WORKAROUND_SECONDS:=15}
 
 REDIS_SERVER=$(find_binary_or_die redis-server)
 REDIS_CLI=$(find_binary_or_die redis-cli)
@@ -29,6 +29,33 @@ wait_redis_ready() {
         sleep 1
     done
     die "Failed to connect to redis instance on port $HOST:$PORT"
+}
+
+wait_for_redis_nodes_election() {
+    local CURRENT_REPLICAS_COUNT=0
+    local EXPECTED_REPLICAS_COUNT=999
+    local CURRENT_NODES_REPONSE=
+    local CURRENT_MASTERS_COUNT=
+    for i in $(seq 1 ${REDIS_SLEEP_WORKAROUND_SECONDS}); do
+        for port in ${REDIS_CLUSTER_PORTS}; do
+            CURRENT_NODES_REPONSE=$($REDIS_CLI -h $REDIS_HOST -p $port CLUSTER NODES)
+            CURRENT_MASTERS_COUNT=$(echo "$CURRENT_NODES_REPONSE" | grep 'master' | wc -l)
+            CURRENT_REPLICAS_COUNT=$(echo "$CURRENT_NODES_REPONSE" | grep 'slave\|replica' | wc -l)
+            EXPECTED_REPLICAS_COUNT=$(expr $CURRENT_MASTERS_COUNT \* $REDIS_CLUSTER_REPLICAS)
+            if [ "x$EXPECTED_REPLICAS_COUNT" != "x$CURRENT_REPLICAS_COUNT" ]; then
+                break
+            fi
+        done
+
+        if [ "x$EXPECTED_REPLICAS_COUNT" = "x$CURRENT_REPLICAS_COUNT" ]; then
+            return
+        fi
+
+        sleep 1
+    done
+
+    die "Failed to start redis cluster in ${REDIS_SLEEP_WORKAROUND_SECONDS} seconds. \
+        Try increasing the REDIS_SLEEP_WORKAROUND_SECONDS."
 }
 
 start() {
@@ -54,6 +81,9 @@ start() {
             dump_log_stderr "$logfile"
             die "Failed to start redis ($port) server"
         }
+    done
+
+    for port in ${REDIS_CLUSTER_PORTS}; do
         wait_redis_ready $REDIS_HOST $port
         REDIS_INSTS="$REDIS_INSTS $REDIS_HOST:$port"
     done
@@ -63,9 +93,10 @@ start() {
         --cluster-replicas $REDIS_CLUSTER_REPLICAS \
         --cluster-yes || \
         die "Failed to create a redis cluster"
-    echo "Created redis cluster ..."
 
-    sleep $REDIS_SLEEP_WORKAROUND_SECONDS
+    wait_for_redis_nodes_election
+
+    echo "Created redis cluster ..."
 }
 
 stop() {

--- a/testsuite/databases/redis/scripts/service-cluster-redis
+++ b/testsuite/databases/redis/scripts/service-cluster-redis
@@ -42,12 +42,12 @@ wait_for_redis_nodes_election() {
             CURRENT_MASTERS_COUNT=$(echo "$CURRENT_NODES_REPONSE" | grep 'master' | wc -l)
             CURRENT_REPLICAS_COUNT=$(echo "$CURRENT_NODES_REPONSE" | grep 'slave\|replica' | wc -l)
             EXPECTED_REPLICAS_COUNT=$(expr $CURRENT_MASTERS_COUNT \* $REDIS_CLUSTER_REPLICAS)
-            if [ $EXPECTED_REPLICAS_COUNT -ne $CURRENT_REPLICAS_COUNT ]; then
+            if [ "$EXPECTED_REPLICAS_COUNT" -ne "$CURRENT_REPLICAS_COUNT" ]; then
                 break
             fi
         done
 
-        if [ $EXPECTED_REPLICAS_COUNT -eq $CURRENT_REPLICAS_COUNT ]; then
+        if [ "$EXPECTED_REPLICAS_COUNT" -eq "$CURRENT_REPLICAS_COUNT" ]; then
             return
         fi
 


### PR DESCRIPTION
The change guarantees that the Redis cluster has all the replicas ready when returning from the `service-cluster-redis` script. Also improve nodes startup time by starting all the nodes before doing actual checks for nodes being ready.