### PR TITLE
Drop legacy `loop` fixutre support

### DIFF
--- a/testsuite/plugins/asyncio/__init__.py
+++ b/testsuite/plugins/asyncio/__init__.py
@@ -1,16 +1,9 @@
 import asyncio
-import warnings
 
 import pytest_aiohttp
 from packaging import version
 
 PYTEST_ASYNCIO_VERSION = version.parse('0.22')
-
-LOOP_DEPRECATION_MESSAGE = """\
-Testsuite fixtures `event_loop` and `loop` are deprecated.
-
-Tests and fixtures should use "asyncio.get_running_loop()" instead.
-Please use `async def` for tests and fixtures that are meant to run in asyncio event_loop."""
 
 
 def _pytest_asyncio_legacy():
@@ -26,12 +19,3 @@ if _pytest_asyncio_legacy():
     from .plugin_legacy import *
 else:
     from .plugin import *
-
-
-@pytest.fixture(scope='session')
-async def loop(event_loop):
-    warnings.warn(
-        LOOP_DEPRECATION_MESSAGE,
-        pytest.PytestDeprecationWarning,
-    )
-    return asyncio.get_running_loop()

--- a/testsuite/plugins/asyncio/plugin.py
+++ b/testsuite/plugins/asyncio/plugin.py
@@ -1,8 +1,3 @@
-import asyncio
-
-import pytest
-
-
 def pytest_configure(config):
     # Force default asyncio mode
     config.option.asyncio_mode = 'auto'
@@ -16,8 +11,3 @@ def pytest_collection_modifyitems(items):
         mark = item.get_closest_marker('asyncio')
         if mark:
             mark.kwargs.setdefault('loop_scope', 'session')
-
-
-@pytest.fixture(scope='session')
-async def event_loop():
-    return asyncio.get_running_loop()

--- a/testsuite/plugins/asyncio/warnings.py
+++ b/testsuite/plugins/asyncio/warnings.py
@@ -1,5 +1,0 @@
-LOOP_DEPRECATION_MESSAGE = """\
-Testsuite fixtures `event_loop` and `loop` are deprecated.
-
-Tests and fixtures should use "asyncio.get_running_loop()" instead. Don't
-forget to use async keyword when defining them."""


### PR DESCRIPTION
`event_loop` is removed for new pytest-asyncio package.