### PR TITLE
Specify tmp dir path inside tests

### DIFF
--- a/tests/core/pytest.ini
+++ b/tests/core/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --log-level debug --strict-markers
+addopts = --log-level debug --strict-markers --basetemp=/tmp/pytest
 mockserver-ssl-cert-file = static/default/mockserver_ssl.crt
 mockserver-ssl-key-file = static/default/mockserver_ssl.key
 mockserver-tracing-enabled = True


### PR DESCRIPTION
On MacOS default tmp dir path is too long to be used in unix sockets