### PR TITLE
Add WebSocket support to mockserver

### DIFF
--- a/docs/mockserver.rst
+++ b/docs/mockserver.rst
@@ -318,6 +318,30 @@ path in the http request.
        # POST requests.
        return {}
 
+WebSocket support
+-----------------
+
+Mockserver supports WebSocket connections.
+
+Example:
+
+.. code-block:: python
+
+   @mockserver.aiohttp_handler('/ws/chat')
+   async def ws_handler(request):
+       ws = aiohttp.web.WebSocketResponse()
+       await ws.prepare(request)
+
+       async for msg in ws:
+           if msg.type == aiohttp.WSMsgType.TEXT:
+               await ws.send_str(msg.data)
+           elif msg.type == aiohttp.WSMsgType.BINARY:
+               await ws.send_bytes(msg.data)
+           elif msg.type == aiohttp.WSMsgType.ERROR:
+               break
+
+       return ws
+
 OpenTracing
 -----------
 

--- a/tests/core/plugins/mockserver/test_mockserver.py
+++ b/tests/core/plugins/mockserver/test_mockserver.py
@@ -141,3 +141,25 @@ async def test_direct_addresses(
                 headers={'Host': f'localhost:{port}'},
             )
             assert response.status == 200
+
+
+async def test_websocket(
+    mockserver: testsuite.MockserverFixture,
+):
+    @mockserver.aiohttp_handler('/ws/chat')
+    async def ws_handler(request):
+        ws = aiohttp.web.WebSocketResponse()
+        await ws.prepare(request)
+
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                assert msg.data == 'message'
+                await ws.send_str('answer')
+
+        return ws
+
+    async with aiohttp.ClientSession() as session:
+        async with session.ws_connect(mockserver.ws_url('/ws/chat')) as ws:
+            await ws.send_str('message')
+            msg = await ws.receive()
+            assert msg.data == 'answer'

--- a/testsuite/mockserver/classes.py
+++ b/testsuite/mockserver/classes.py
@@ -60,6 +60,10 @@ class MockserverInfo:
             return str(self.host)
         return f'{self.host}:{self.port}'
 
+    def ws_url(self, path: str) -> str:
+        schema = 'wss' if self.https else 'ws'
+        return url_util.join(f'{schema}://{self.host}:{self.port}/', path)
+
 
 @dataclasses.dataclass(frozen=True)
 class MockserverSocket:

--- a/testsuite/mockserver/server.py
+++ b/testsuite/mockserver/server.py
@@ -179,7 +179,9 @@ class Session:
             response = await handler(request, **kwargs)
             if isinstance(response, http.Response):
                 return response.to_aiohttp()
-            elif isinstance(response, (aiohttp.web.Response, aiohttp.web.WebSocketResponse)):
+            elif isinstance(
+                response, (aiohttp.web.Response, aiohttp.web.WebSocketResponse)
+            ):
                 return response
             elif isinstance(response, http.MockedError):
                 return _mocked_error_response(request, response.error_code)

--- a/testsuite/mockserver/server.py
+++ b/testsuite/mockserver/server.py
@@ -181,6 +181,8 @@ class Session:
                 return response.to_aiohttp()
             elif isinstance(response, aiohttp.web.Response):
                 return response
+            elif isinstance(response, aiohttp.web.WebSocketResponse):
+                return response
             elif isinstance(response, http.MockedError):
                 return _mocked_error_response(request, response.error_code)
             raise exceptions.MockServerError(
@@ -559,6 +561,9 @@ class MockserverFixture:
     def url_encoded(self, path: str) -> yarl.URL:
         """Builds mockserver url for ``path``"""
         return yarl.URL(url_util.join(self.base_url, path), encoded=True)
+
+    def ws_url(self, path: str) -> str:
+        return self._server.server_info.ws_url(path)
 
     def ignore_trace_id(self) -> typing.ContextManager[None]:
         return self.tracing(False)

--- a/testsuite/mockserver/server.py
+++ b/testsuite/mockserver/server.py
@@ -179,9 +179,7 @@ class Session:
             response = await handler(request, **kwargs)
             if isinstance(response, http.Response):
                 return response.to_aiohttp()
-            elif isinstance(response, aiohttp.web.Response):
-                return response
-            elif isinstance(response, aiohttp.web.WebSocketResponse):
+            elif isinstance(response, (aiohttp.web.Response, aiohttp.web.WebSocketResponse)):
                 return response
             elif isinstance(response, http.MockedError):
                 return _mocked_error_response(request, response.error_code)


### PR DESCRIPTION
## Summary
This PR adds WebSocket support to the testsuite mockserver.

## Changes
- Added WebSocket handler support in `mockserver.aiohttp_handler`
- Added `ws_url()` method to `MockserverFixture` and `MockserverInfo` classes to generate WebSocket URLs
- Updated session request processing to handle `WebSocketResponse`
- Added documentation with WebSocket usage example
- Added `test_websocket` test to verify WebSocket functionality
