### PR TITLE
Move CompareVisitor/Reporter to a public testsuite.utils.compare module

### DIFF
--- a/testsuite/__init__.py
+++ b/testsuite/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    'CompareVisitor',
     'DaemonInstance',
     'MockserverInfo',
     'MockserverFixture',
@@ -21,6 +22,7 @@ from . import types as annotations  # noqa: F401
 from ._version import __version__  # noqa: F401
 
 # For annotations
+from .compare import CompareVisitor
 from .daemons.classes import DaemonInstance
 from .mockserver.classes import MockserverInfo, MockserverRequest
 from .mockserver.server import MockserverFixture

--- a/testsuite/_internal/compare_transform.py
+++ b/testsuite/_internal/compare_transform.py
@@ -1,35 +1,12 @@
 import collections
 import contextlib
-import dataclasses
 import typing
 
 import py.io
 
+from testsuite.compare import CompareVisitor
+
 SetTypes = (set, frozenset)
-
-
-class Reporter(typing.Protocol):
-    def __call__(self, msg: str, *, path: typing.Any) -> None:
-        pass
-
-
-@dataclasses.dataclass
-class CompareVisitor:
-    class Predicate(typing.Protocol):
-        def __call__(self, left: typing.Any, right: typing.Any) -> bool:
-            pass
-
-    class Visitor(typing.Protocol):
-        def __call__(
-            self,
-            left: typing.Any,
-            right: typing.Any,
-            reporter: Reporter,
-        ) -> tuple[typing.Any, typing.Any]:
-            pass
-
-    predicate: Predicate
-    visit: Visitor
 
 
 class CompareTransform:

--- a/testsuite/compare.py
+++ b/testsuite/compare.py
@@ -1,0 +1,33 @@
+import dataclasses
+import typing
+
+
+class Reporter(typing.Protocol):
+    def __call__(self, msg: str, *, path: typing.Any) -> None:
+        pass
+
+
+@dataclasses.dataclass(kw_only=True)
+class CompareVisitor:
+    """
+    Extension point for `pytest_register_compare_visitors`: lets a plugin
+    teach the `assertrepr_compare` machinery how to decompose a custom type
+    into something comparable (e.g. a nested dict/list/set), so that a
+    failing `==` assertion involving it gets a helpful diff.
+    """
+
+    class Predicate(typing.Protocol):
+        def __call__(self, left: typing.Any, right: typing.Any) -> bool:
+            pass
+
+    class Visitor(typing.Protocol):
+        def __call__(
+            self,
+            left: typing.Any,
+            right: typing.Any,
+            reporter: Reporter,
+        ) -> tuple[typing.Any, typing.Any]:
+            pass
+
+    predicate: Predicate
+    visit: Visitor

--- a/testsuite/plugins/assertrepr_compare.py
+++ b/testsuite/plugins/assertrepr_compare.py
@@ -8,7 +8,7 @@ import typing
 import pytest
 
 from testsuite._internal import compare_transform
-from testsuite._internal.compare_transform import CompareVisitor
+from testsuite.compare import CompareVisitor
 
 
 class AssertMode(enum.Enum):
@@ -18,8 +18,8 @@ class AssertMode(enum.Enum):
 
 
 class CompareVisitorsHookspec:
-    def pytest_register_compare_visitors(self):
-        pass
+    def pytest_register_compare_visitors(self) -> list[CompareVisitor]:
+        raise NotImplementedError
 
 
 def pytest_addhooks(pluginmanager):


### PR DESCRIPTION
CompareVisitor was only reachable via the internal testsuite._internal.compare_transform module, making it awkward for plugins to build their own pytest_register_compare_visitors hooks. Also skip wrapping the pytest default explanation when nothing could be decomposed for comparison, and add a return type to the pytest_register_compare_visitors hookspec.