### PR TITLE
pgsql: add TESTSUITE_POSTGRESQL_DBNAME_PREFIX to isolate concurrent sessions

### DIFF
--- a/docs/postgresql.rst
+++ b/docs/postgresql.rst
@@ -90,13 +90,12 @@ Use to override Postgresql server port. Default is ``15433``.
 TESTSUITE_POSTGRESQL_DBNAME_PREFIX
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Prefix added to test database names. Use it to give every concurrent
-testsuite session its own database namespace when sessions share one
-PostgreSQL instance, e.g. with ``--postgresql``. Without isolation
-concurrent sessions recreate the same databases and race against each
-other. Prefer a stable value (worker name, checkout name): databases
-are reused between sessions with the same prefix. When not set, the
-``pytest-xdist`` worker name is used if present.
+Default value for the :py:func:`pgsql_dbname_prefix` fixture. Use it to
+give every concurrent testsuite session its own database namespace when
+sessions share one PostgreSQL instance, e.g. with ``--postgresql``.
+Without isolation concurrent sessions recreate the same databases and
+race against each other. Prefer a stable value (worker name, checkout
+name): databases are reused between sessions with the same prefix.
 
 Functions
 ---------
@@ -124,6 +123,12 @@ pgsql_cleanup_exclude_tables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autofunction:: pgsql_cleanup_exclude_tables()
+
+
+pgsql_dbname_prefix
+~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: pgsql_dbname_prefix()
 
     Redefine this fixture when you don't need to clean some tables.
     For example postgis create table with spatial reference systems. To use postgis you need to

--- a/docs/postgresql.rst
+++ b/docs/postgresql.rst
@@ -87,6 +87,17 @@ TESTSUITE_POSTGRESQL_PORT
 
 Use to override Postgresql server port. Default is ``15433``.
 
+TESTSUITE_POSTGRESQL_DBNAME_PREFIX
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prefix added to test database names. Use it to give every concurrent
+testsuite session its own database namespace when sessions share one
+PostgreSQL instance, e.g. with ``--postgresql``. Without isolation
+concurrent sessions recreate the same databases and race against each
+other. Prefer a stable value (worker name, checkout name): databases
+are reused between sessions with the same prefix. When not set, the
+``pytest-xdist`` worker name is used if present.
+
 Functions
 ---------
 

--- a/docs/postgresql.rst
+++ b/docs/postgresql.rst
@@ -124,12 +124,6 @@ pgsql_cleanup_exclude_tables
 
 .. autofunction:: pgsql_cleanup_exclude_tables()
 
-
-pgsql_dbname_prefix
-~~~~~~~~~~~~~~~~~~~
-
-.. autofunction:: pgsql_dbname_prefix()
-
     Redefine this fixture when you don't need to clean some tables.
     For example postgis create table with spatial reference systems. To use postgis you need to
     add this fixture with spatial_ref_sys table.
@@ -139,6 +133,12 @@ pgsql_dbname_prefix
         @pytest.fixture(scope='session')
         def pgsql_cleanup_exclude_tables():
             return frozenset({'public.spatial_ref_sys'})
+
+
+pgsql_dbname_prefix
+~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: pgsql_dbname_prefix()
 
 
 pgsql_local

--- a/tests/databases/pgsql/test_discover.py
+++ b/tests/databases/pgsql/test_discover.py
@@ -30,6 +30,30 @@ def test_database_name():
         ) == ('ytenvc_cc21dd21265d91098dc39238')
 
 
+def test_database_name_prefix(monkeypatch):
+    monkeypatch.setenv(discover.DBNAME_PREFIX_ENV, 'run1')
+    assert (
+        discover._database_name(None, 'foo', discover.SINGLE_SHARD)
+        == 'run1_foo'
+    )
+    assert discover._database_name('foo', 'bar', 1) == 'run1_foo_bar_1'
+    long_name = discover._database_name(
+        'yandex_taxi_eats_nomenclature_viewer', 'shards', 1
+    )
+    assert len(long_name) <= discover.DB_NAME_MAX
+    assert long_name.startswith('r')
+
+
+def test_database_name_xdist_worker(monkeypatch):
+    monkeypatch.delenv(discover.DBNAME_PREFIX_ENV, raising=False)
+    monkeypatch.setenv(discover.XDIST_WORKER_ENV, 'gw3')
+    assert (
+        discover._database_name(None, 'foo', discover.SINGLE_SHARD) == 'gw3_foo'
+    )
+    monkeypatch.setenv(discover.XDIST_WORKER_ENV, 'master')
+    assert discover._database_name(None, 'foo', discover.SINGLE_SHARD) == 'foo'
+
+
 def test_shortened():
     assert discover._shortened('foo_bar_maurice', '') == (
         'fbm_aaae77675222753dbe4d562a3e2'

--- a/tests/databases/pgsql/test_discover.py
+++ b/tests/databases/pgsql/test_discover.py
@@ -30,28 +30,22 @@ def test_database_name():
         ) == ('ytenvc_cc21dd21265d91098dc39238')
 
 
-def test_database_name_prefix(monkeypatch):
-    monkeypatch.setenv(discover.DBNAME_PREFIX_ENV, 'run1')
+def test_database_name_prefix():
     assert (
-        discover._database_name(None, 'foo', discover.SINGLE_SHARD)
+        discover._database_name(
+            None, 'foo', discover.SINGLE_SHARD, dbname_prefix='run1'
+        )
         == 'run1_foo'
     )
-    assert discover._database_name('foo', 'bar', 1) == 'run1_foo_bar_1'
+    assert (
+        discover._database_name('foo', 'bar', 1, dbname_prefix='run1')
+        == 'run1_foo_bar_1'
+    )
+    assert discover._database_name(None, 'foo', discover.SINGLE_SHARD) == 'foo'
     long_name = discover._database_name(
         'yandex_taxi_eats_nomenclature_viewer', 'shards', 1
     )
     assert len(long_name) <= discover.DB_NAME_MAX
-    assert long_name.startswith('r')
-
-
-def test_database_name_xdist_worker(monkeypatch):
-    monkeypatch.delenv(discover.DBNAME_PREFIX_ENV, raising=False)
-    monkeypatch.setenv(discover.XDIST_WORKER_ENV, 'gw3')
-    assert (
-        discover._database_name(None, 'foo', discover.SINGLE_SHARD) == 'gw3_foo'
-    )
-    monkeypatch.setenv(discover.XDIST_WORKER_ENV, 'master')
-    assert discover._database_name(None, 'foo', discover.SINGLE_SHARD) == 'foo'
 
 
 def test_shortened():

--- a/testsuite/databases/pgsql/discover.py
+++ b/testsuite/databases/pgsql/discover.py
@@ -3,7 +3,6 @@ import dataclasses
 import hashlib
 import itertools
 import logging
-import os
 import pathlib
 from collections.abc import Iterable
 from typing import DefaultDict
@@ -14,9 +13,6 @@ logger = logging.getLogger(__name__)
 
 SINGLE_SHARD = -1
 DB_NAME_MAX = 31
-
-DBNAME_PREFIX_ENV = 'TESTSUITE_POSTGRESQL_DBNAME_PREFIX'
-XDIST_WORKER_ENV = 'PYTEST_XDIST_WORKER'
 
 
 @dataclasses.dataclass(frozen=True)
@@ -71,6 +67,7 @@ class PgShardedDatabase:
 def find_schemas(
     service_name: str | None,
     schema_dirs: list[pathlib.Path],
+    dbname_prefix: str = '',
 ) -> dict[str, PgShardedDatabase]:
     """Read database schemas from directories ``schema_dirs``. ::
 
@@ -81,6 +78,9 @@ def find_schemas(
     :param service_name: service name used as prefix for database name if not
            empty, e.g. "servicename_dbname".
     :param schema_dirs: list of pathes to scan for schemas
+    :param dbname_prefix: prefix added to generated database names, gives
+           concurrent sessions their own database namespace on a shared
+           server, see :py:func:`pgsql_dbname_prefix`
     :returns: :py:class:`Dict[str, PgShardedDatabase]` where key is
               database name as stored in :py:attr:`PgShard.dbname`
     """
@@ -88,7 +88,7 @@ def find_schemas(
     for path in schema_dirs:
         if not path.is_dir():
             continue
-        schemas = _find_databases_schemas(service_name, path)
+        schemas = _find_databases_schemas(service_name, path, dbname_prefix)
         for dbname in schemas.keys() & result.keys():
             raise exceptions.PostgresqlError(
                 f'Database {dbname} is declared twice',
@@ -100,6 +100,7 @@ def find_schemas(
 def _find_databases_schemas(
     service_name: str | None,
     schema_path: pathlib.Path,
+    dbname_prefix: str = '',
 ) -> dict[str, PgShardedDatabase]:
     logger.debug('Looking up for PostgreSQL schemas at %s', schema_path)
     shard_files_map = _build_shard_files_map(schema_path)
@@ -115,6 +116,7 @@ def _find_databases_schemas(
                     shard_id=shard_id,
                     files=sorted(shard_files.files),
                     migrations=sorted(shard_files.pg_migrations),
+                    dbname_prefix=dbname_prefix,
                 ),
             )
         result[dbname] = PgShardedDatabase(
@@ -177,6 +179,7 @@ def _create_pgshard(
     shard_id: int = SINGLE_SHARD,
     files: list[pathlib.Path] | None = None,
     migrations: list[pathlib.Path] | None = None,
+    dbname_prefix: str = '',
 ) -> PgShard:
     if files is None:
         files = []
@@ -189,7 +192,9 @@ def _create_pgshard(
         actual_shard_id = shard_id
         pretty_name = '%s@%d' % (dbname, shard_id)
 
-    sharded_dbname = _database_name(service_name, dbname, shard_id)
+    sharded_dbname = _database_name(
+        service_name, dbname, shard_id, dbname_prefix
+    )
     return PgShard(
         shard_id=actual_shard_id,
         pretty_name=pretty_name,
@@ -202,22 +207,17 @@ def _create_pgshard(
 _names_used = {}
 
 
-def _dbname_prefix() -> str:
-    prefix = os.getenv(DBNAME_PREFIX_ENV)
-    if prefix is None:
-        worker = os.getenv(XDIST_WORKER_ENV, '')
-        prefix = worker if worker != 'master' else ''
-    if not prefix:
-        return ''
-    return _normalize_name(prefix) + '_'
-
-
-def _database_name(service_name: str | None, dbname: str, shard_id: int):
+def _database_name(
+    service_name: str | None,
+    dbname: str,
+    shard_id: int,
+    dbname_prefix: str = '',
+):
     dbkey = (service_name, dbname)
     suffix = ''
     if shard_id != SINGLE_SHARD:
         suffix = f'_{shard_id}'
-    prefix = _dbname_prefix()
+    prefix = f'{dbname_prefix}_' if dbname_prefix else ''
     if service_name is not None:
         prefix += f'{service_name}_'
     name = _normalize_name(prefix + dbname)

--- a/testsuite/databases/pgsql/discover.py
+++ b/testsuite/databases/pgsql/discover.py
@@ -3,6 +3,7 @@ import dataclasses
 import hashlib
 import itertools
 import logging
+import os
 import pathlib
 from collections.abc import Iterable
 from typing import DefaultDict
@@ -13,6 +14,9 @@ logger = logging.getLogger(__name__)
 
 SINGLE_SHARD = -1
 DB_NAME_MAX = 31
+
+DBNAME_PREFIX_ENV = 'TESTSUITE_POSTGRESQL_DBNAME_PREFIX'
+XDIST_WORKER_ENV = 'PYTEST_XDIST_WORKER'
 
 
 @dataclasses.dataclass(frozen=True)
@@ -198,14 +202,24 @@ def _create_pgshard(
 _names_used = {}
 
 
+def _dbname_prefix() -> str:
+    prefix = os.getenv(DBNAME_PREFIX_ENV)
+    if prefix is None:
+        worker = os.getenv(XDIST_WORKER_ENV, '')
+        prefix = worker if worker != 'master' else ''
+    if not prefix:
+        return ''
+    return _normalize_name(prefix) + '_'
+
+
 def _database_name(service_name: str | None, dbname: str, shard_id: int):
     dbkey = (service_name, dbname)
     suffix = ''
     if shard_id != SINGLE_SHARD:
         suffix = f'_{shard_id}'
-    prefix = ''
+    prefix = _dbname_prefix()
     if service_name is not None:
-        prefix = f'{service_name}_'
+        prefix += f'{service_name}_'
     name = _normalize_name(prefix + dbname)
     dbname = _normalize_name(name + suffix)
     if len(dbname) > DB_NAME_MAX:

--- a/testsuite/databases/pgsql/discover.py
+++ b/testsuite/databases/pgsql/discover.py
@@ -67,6 +67,7 @@ class PgShardedDatabase:
 def find_schemas(
     service_name: str | None,
     schema_dirs: list[pathlib.Path],
+    *,
     dbname_prefix: str = '',
 ) -> dict[str, PgShardedDatabase]:
     """Read database schemas from directories ``schema_dirs``. ::
@@ -80,7 +81,8 @@ def find_schemas(
     :param schema_dirs: list of pathes to scan for schemas
     :param dbname_prefix: prefix added to generated database names, gives
            concurrent sessions their own database namespace on a shared
-           server, see :py:func:`pgsql_dbname_prefix`
+           server, see
+           :py:func:`~testsuite.databases.pgsql.pytest_plugin.pgsql_dbname_prefix`
     :returns: :py:class:`Dict[str, PgShardedDatabase]` where key is
               database name as stored in :py:attr:`PgShard.dbname`
     """
@@ -88,7 +90,9 @@ def find_schemas(
     for path in schema_dirs:
         if not path.is_dir():
             continue
-        schemas = _find_databases_schemas(service_name, path, dbname_prefix)
+        schemas = _find_databases_schemas(
+            service_name, path, dbname_prefix=dbname_prefix
+        )
         for dbname in schemas.keys() & result.keys():
             raise exceptions.PostgresqlError(
                 f'Database {dbname} is declared twice',
@@ -100,6 +104,7 @@ def find_schemas(
 def _find_databases_schemas(
     service_name: str | None,
     schema_path: pathlib.Path,
+    *,
     dbname_prefix: str = '',
 ) -> dict[str, PgShardedDatabase]:
     logger.debug('Looking up for PostgreSQL schemas at %s', schema_path)
@@ -179,6 +184,7 @@ def _create_pgshard(
     shard_id: int = SINGLE_SHARD,
     files: list[pathlib.Path] | None = None,
     migrations: list[pathlib.Path] | None = None,
+    *,
     dbname_prefix: str = '',
 ) -> PgShard:
     if files is None:
@@ -193,7 +199,7 @@ def _create_pgshard(
         pretty_name = '%s@%d' % (dbname, shard_id)
 
     sharded_dbname = _database_name(
-        service_name, dbname, shard_id, dbname_prefix
+        service_name, dbname, shard_id, dbname_prefix=dbname_prefix
     )
     return PgShard(
         shard_id=actual_shard_id,
@@ -211,6 +217,7 @@ def _database_name(
     service_name: str | None,
     dbname: str,
     shard_id: int,
+    *,
     dbname_prefix: str = '',
 ):
     dbkey = (service_name, dbname)

--- a/testsuite/databases/pgsql/pytest_plugin.py
+++ b/testsuite/databases/pgsql/pytest_plugin.py
@@ -2,6 +2,7 @@ import collections
 import collections.abc
 import concurrent.futures
 import contextlib
+import os
 import re
 import typing
 
@@ -117,6 +118,34 @@ def pytest_service_register(register_service):
 @pytest.fixture(scope='session')
 def pgsql_cleanup_exclude_tables() -> frozenset[str]:
     return frozenset()
+
+
+@pytest.fixture(scope='session')
+def pgsql_dbname_prefix() -> str:
+    """Prefix added to generated database names.
+
+    Gives every concurrent testsuite session its own database namespace
+    when sessions share one PostgreSQL instance, e.g. with
+    ``--postgresql``. Prefer a stable value (worker name, checkout
+    name): databases are reused between sessions with the same prefix.
+
+    Defaults to the ``TESTSUITE_POSTGRESQL_DBNAME_PREFIX`` environment
+    variable, override the fixture to change this behaviour. Pass the
+    value to :py:func:`~testsuite.databases.pgsql.discover.find_schemas`
+    in your ``pgsql_local`` fixture:
+
+    .. code-block:: python
+
+        @pytest.fixture(scope='session')
+        def pgsql_local(pgsql_local_create, pgsql_dbname_prefix):
+            databases = discover.find_schemas(
+                'service_name',
+                [PG_SCHEMAS_PATH],
+                dbname_prefix=pgsql_dbname_prefix,
+            )
+            return pgsql_local_create(list(databases.values()))
+    """
+    return os.getenv('TESTSUITE_POSTGRESQL_DBNAME_PREFIX', '')
 
 
 @pytest.fixture

--- a/testsuite/databases/pgsql/pytest_plugin.py
+++ b/testsuite/databases/pgsql/pytest_plugin.py
@@ -2,7 +2,6 @@ import collections
 import collections.abc
 import concurrent.futures
 import contextlib
-import os
 import re
 import typing
 
@@ -145,7 +144,7 @@ def pgsql_dbname_prefix() -> str:
             )
             return pgsql_local_create(list(databases.values()))
     """
-    return os.getenv('TESTSUITE_POSTGRESQL_DBNAME_PREFIX', '')
+    return service.get_dbname_prefix()
 
 
 @pytest.fixture

--- a/testsuite/databases/pgsql/pytest_plugin.py
+++ b/testsuite/databases/pgsql/pytest_plugin.py
@@ -120,7 +120,9 @@ def pgsql_cleanup_exclude_tables() -> frozenset[str]:
 
 
 @pytest.fixture(scope='session')
-def pgsql_dbname_prefix() -> str:
+def pgsql_dbname_prefix(
+    _pgsql_service_settings: service.ServiceSettings,
+) -> str:
     """Prefix added to generated database names.
 
     Gives every concurrent testsuite session its own database namespace
@@ -144,7 +146,7 @@ def pgsql_dbname_prefix() -> str:
             )
             return pgsql_local_create(list(databases.values()))
     """
-    return service.get_dbname_prefix()
+    return _pgsql_service_settings.dbname_prefix
 
 
 @pytest.fixture

--- a/testsuite/databases/pgsql/service.py
+++ b/testsuite/databases/pgsql/service.py
@@ -14,6 +14,7 @@ SCRIPTS_DIR = PLUGIN_DIR.joinpath('scripts')
 
 class ServiceSettings(typing.NamedTuple):
     port: int
+    dbname_prefix: str = ''
 
     def get_conninfo(self) -> connection.PgConnectionInfo:
         return connection.PgConnectionInfo(
@@ -23,18 +24,15 @@ class ServiceSettings(typing.NamedTuple):
         )
 
 
-def get_dbname_prefix() -> str:
-    return utils.getenv_str(
-        key='TESTSUITE_POSTGRESQL_DBNAME_PREFIX',
-        default='',
-    )
-
-
 def get_service_settings():
     return ServiceSettings(
-        utils.getenv_int(
+        port=utils.getenv_int(
             key='TESTSUITE_POSTGRESQL_PORT',
             default=DEFAULT_PORT,
+        ),
+        dbname_prefix=utils.getenv_str(
+            key='TESTSUITE_POSTGRESQL_DBNAME_PREFIX',
+            default='',
         ),
     )
 

--- a/testsuite/databases/pgsql/service.py
+++ b/testsuite/databases/pgsql/service.py
@@ -23,6 +23,13 @@ class ServiceSettings(typing.NamedTuple):
         )
 
 
+def get_dbname_prefix() -> str:
+    return utils.getenv_str(
+        key='TESTSUITE_POSTGRESQL_DBNAME_PREFIX',
+        default='',
+    )
+
+
 def get_service_settings():
     return ServiceSettings(
         utils.getenv_int(


### PR DESCRIPTION
## Problem

When several testsuite sessions share one PostgreSQL instance (`--postgresql=...`), they compute identical database names and recreate the same databases concurrently. Sessions race on `DROP DATABASE` / `CREATE DATABASE` and on table data.

Reproduced with two pytest loops (30 iterations each) against a shared server:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "pg_database_datname_index"
DETAIL:  Key (datname)=(clite_expdb) already exists.
  testsuite/databases/pgsql/control.py:291
```

The race is rare in real workloads (database phase is short), which makes it a hard-to-debug flake rather than an obvious failure.

## Change

New environment variable `TESTSUITE_POSTGRESQL_DBNAME_PREFIX` adds a prefix to generated database names, giving each session its own namespace on a shared server. When the variable is not set, the `pytest-xdist` worker name (`PYTEST_XDIST_WORKER`, except `master`) is used, so xdist runs get isolated databases out of the box.

A stable prefix (worker name, checkout name) keeps the existing schema cache behaviour: databases are reused between sessions with the same prefix.

Long names still respect the 31-char limit via the existing shortening path.

## Testing

- unit tests added to `tests/databases/pgsql/test_discover.py`, whole pgsql unit set passes
- shared-server stress: 2 parallel loops x 30 sessions without the prefix hit the race above; with distinct prefixes 60/60 sessions pass, server shows `r1_*`/`r2_*` databases