### PR TITLE
mysql, clickhouse: add dbprefix fixtures for concurrent sessions

### DIFF
--- a/docs/clickhouse.rst
+++ b/docs/clickhouse.rst
@@ -51,6 +51,15 @@ By default testsuite will wait for up to 20s for ClickHouse to start,
 one may customize this timeout via environment variable ``TESTSUITE_CLICKHOUSE_SERVER_START_TIMEOUT``.
 
 
+
+TESTSUITE_CLICKHOUSE_DBNAME_PREFIX
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Extends the database name prefix so that every concurrent testsuite
+session gets its own database namespace on a shared server. Prefer a
+stable value (worker name, checkout name): databases are reused between
+sessions with the same prefix. See :py:func:`clickhouse_dbprefix`.
+
 Customize ports
 ---------------
 
@@ -123,6 +132,13 @@ clickhouse_conn_info
 
 .. autofunction:: clickhouse_conn_info()
   :noindex:
+
+
+
+clickhouse_dbprefix
+~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: clickhouse_dbprefix()
 
 
 Marks

--- a/docs/mysql.rst
+++ b/docs/mysql.rst
@@ -30,6 +30,15 @@ TESTSUITE_MYSQL_SERVER_START_TIMEOUT
 By default testsuite will wait for up to 10s for MySQL to start,
 one may customize this timeout via environment variable ``TESTSUITE_MYSQL_SERVER_START_TIMEOUT``.
 
+
+TESTSUITE_MYSQL_DBNAME_PREFIX
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Extends the database name prefix so that every concurrent testsuite
+session gets its own database namespace on a shared server. Prefer a
+stable value (worker name, checkout name): databases are reused between
+sessions with the same prefix. See :py:func:`mysql_dbprefix`.
+
 Customize port
 --------------
 
@@ -105,6 +114,13 @@ mysql_conninfo
 
 .. autofunction:: mysql_conninfo()
   :noindex:
+
+
+
+mysql_dbprefix
+~~~~~~~~~~~~~~
+
+.. autofunction:: mysql_dbprefix()
 
 
 Marks

--- a/tests/databases/clickhouse/test_discover.py
+++ b/tests/databases/clickhouse/test_discover.py
@@ -1,0 +1,16 @@
+from testsuite.databases.clickhouse import discover, service
+
+
+def test_find_schemas_dbprefix(tmp_path):
+    (tmp_path / 'testdb.sql').write_text('CREATE TABLE foo (id INT);')
+    schemas = discover.find_schemas([tmp_path])
+    assert schemas['testdb'].dbname == 'testsuite-testdb'
+    schemas = discover.find_schemas([tmp_path], dbprefix='testsuite-gw1-')
+    assert schemas['testdb'].dbname == 'testsuite-gw1-testdb'
+
+
+def test_get_dbprefix(monkeypatch):
+    monkeypatch.delenv('TESTSUITE_CLICKHOUSE_DBNAME_PREFIX', raising=False)
+    assert service.get_dbprefix() == 'testsuite-'
+    monkeypatch.setenv('TESTSUITE_CLICKHOUSE_DBNAME_PREFIX', 'gw1')
+    assert service.get_dbprefix() == 'testsuite-gw1-'

--- a/tests/databases/mysql/test_discover.py
+++ b/tests/databases/mysql/test_discover.py
@@ -1,0 +1,16 @@
+from testsuite.databases.mysql import discover, service
+
+
+def test_find_schemas_dbprefix(tmp_path):
+    (tmp_path / 'testdb.sql').write_text('CREATE TABLE foo (id INT);')
+    schemas = discover.find_schemas([tmp_path])
+    assert schemas['testdb'].dbname == 'testsuite-testdb'
+    schemas = discover.find_schemas([tmp_path], dbprefix='testsuite-gw1-')
+    assert schemas['testdb'].dbname == 'testsuite-gw1-testdb'
+
+
+def test_get_dbprefix(monkeypatch):
+    monkeypatch.delenv('TESTSUITE_MYSQL_DBNAME_PREFIX', raising=False)
+    assert service.get_dbprefix() == 'testsuite-'
+    monkeypatch.setenv('TESTSUITE_MYSQL_DBNAME_PREFIX', 'gw1')
+    assert service.get_dbprefix() == 'testsuite-gw1-'

--- a/testsuite/databases/clickhouse/pytest_plugin.py
+++ b/testsuite/databases/clickhouse/pytest_plugin.py
@@ -140,6 +140,32 @@ def clickhouse_disabled(pytestconfig) -> bool:
 
 
 @pytest.fixture(scope='session')
+def clickhouse_dbprefix() -> str:
+    """Prefix for test database names.
+
+    Gives every concurrent testsuite session its own database namespace
+    when sessions share one ClickHouse instance. Prefer a stable value
+    (worker name, checkout name): databases are reused between sessions
+    with the same prefix.
+
+    Defaults to ``testsuite-``, extended from the ``TESTSUITE_CLICKHOUSE_DBNAME_PREFIX``
+    environment variable, override the fixture to change this
+    behaviour. Pass the value to
+    :py:func:`~testsuite.databases.clickhouse.discover.find_schemas`
+    in your ``clickhouse_local`` fixture:
+
+    .. code-block:: python
+
+        @pytest.fixture(scope='session')
+        def clickhouse_local(clickhouse_dbprefix):
+            return discover.find_schemas(
+                [SCHEMAS_DIR], dbprefix=clickhouse_dbprefix
+            )
+    """
+    return service.get_dbprefix()
+
+
+@pytest.fixture(scope='session')
 def clickhouse_local() -> classes.DatabasesDict:
     """Use to override databases configuration."""
     return {}

--- a/testsuite/databases/clickhouse/service.py
+++ b/testsuite/databases/clickhouse/service.py
@@ -25,6 +25,16 @@ class ServiceSettings(typing.NamedTuple):
         )
 
 
+def get_dbprefix() -> str:
+    namespace = utils.getenv_str(
+        key='TESTSUITE_CLICKHOUSE_DBNAME_PREFIX',
+        default='',
+    )
+    if namespace:
+        return f'testsuite-{namespace}-'
+    return 'testsuite-'
+
+
 def create_clickhouse_service(
     service_name,
     working_dir,

--- a/testsuite/databases/mysql/pytest_plugin.py
+++ b/testsuite/databases/mysql/pytest_plugin.py
@@ -49,6 +49,32 @@ def mysql_conninfo(pytestconfig, _mysql_service_settings):
 
 
 @pytest.fixture(scope='session')
+def mysql_dbprefix() -> str:
+    """Prefix for test database names.
+
+    Gives every concurrent testsuite session its own database namespace
+    when sessions share one MySQL instance. Prefer a stable value
+    (worker name, checkout name): databases are reused between sessions
+    with the same prefix.
+
+    Defaults to ``testsuite-``, extended from the ``TESTSUITE_MYSQL_DBNAME_PREFIX``
+    environment variable, override the fixture to change this
+    behaviour. Pass the value to
+    :py:func:`~testsuite.databases.mysql.discover.find_schemas`
+    in your ``mysql_local`` fixture:
+
+    .. code-block:: python
+
+        @pytest.fixture(scope='session')
+        def mysql_local(mysql_dbprefix):
+            return discover.find_schemas(
+                [SCHEMAS_DIR], dbprefix=mysql_dbprefix
+            )
+    """
+    return service.get_dbprefix()
+
+
+@pytest.fixture(scope='session')
 def mysql_local() -> classes.DatabasesDict:
     """Use to override databases configuration."""
     return {}

--- a/testsuite/databases/mysql/service.py
+++ b/testsuite/databases/mysql/service.py
@@ -12,6 +12,16 @@ PLUGIN_DIR = pathlib.Path(__file__).parent
 SCRIPTS_DIR = PLUGIN_DIR.joinpath('scripts')
 
 
+def get_dbprefix() -> str:
+    namespace = utils.getenv_str(
+        key='TESTSUITE_MYSQL_DBNAME_PREFIX',
+        default='',
+    )
+    if namespace:
+        return f'testsuite-{namespace}-'
+    return 'testsuite-'
+
+
 def create_service(
     service_name: str,
     working_dir: str,


### PR DESCRIPTION
Follow-up to #229: the same problem for MySQL and ClickHouse — concurrent testsuite sessions sharing one server compute identical database names and recreate each other's databases.

## Change

Both modules already accept a prefix via the existing `find_schemas(..., dbprefix=...)` argument, so no API changes: new session-scoped fixtures `mysql_dbprefix` / `clickhouse_dbprefix` return the ready-to-use prefix — `testsuite-` by default, extended to `testsuite-<namespace>-` from `TESTSUITE_MYSQL_DBNAME_PREFIX` / `TESTSUITE_CLICKHOUSE_DBNAME_PREFIX`. Env defaults are read in `service.py` via `utils.getenv_str`, same as the other settings there. Docs updated (env vars + fixtures).

Mongo is left out on purpose: databases there are configured per collection, a namespace needs a different design.

## Testing

- new pure unit tests for `find_schemas` prefixing and `get_dbprefix` env handling — pass
- ruff check/format and mypy are clean on the changed files (the only mypy complaint is the pre-existing `clickhouse_driver` import without stubs, absent from this diff)
- live mysql/clickhouse suites — via CI