### PR TITLE
Support TESTSUITE_POSTGRESQL_PORT=auto to allocate a free port

### DIFF
--- a/docs/postgresql.rst
+++ b/docs/postgresql.rst
@@ -87,6 +87,11 @@ TESTSUITE_POSTGRESQL_PORT
 
 Use to override Postgresql server port. Default is ``15433``.
 
+Special value ``auto`` allocates a free port automatically. Use it to run
+multiple isolated environments on one machine, e.g. in combination with
+``--env-dir``. Automatically allocated port changes between sessions,
+so environment reuse (``--auto-env``) restarts the server.
+
 Functions
 ---------
 

--- a/tests/core/environment/test_utils.py
+++ b/tests/core/environment/test_utils.py
@@ -1,0 +1,37 @@
+import pytest
+
+from testsuite.environment import utils
+
+
+def test_getenv_port_default(monkeypatch):
+    monkeypatch.delenv('TESTSUITE_TEST_PORT', raising=False)
+    assert utils.getenv_port(key='TESTSUITE_TEST_PORT', default=1234) == 1234
+
+
+def test_getenv_port_explicit(monkeypatch):
+    monkeypatch.setenv('TESTSUITE_TEST_PORT', '4321')
+    assert utils.getenv_port(key='TESTSUITE_TEST_PORT', default=1234) == 4321
+
+
+def test_getenv_port_invalid(monkeypatch):
+    monkeypatch.setenv('TESTSUITE_TEST_PORT', 'foobar')
+    with pytest.raises(utils.EnvironmentVariableError):
+        utils.getenv_port(key='TESTSUITE_TEST_PORT', default=1234)
+
+
+def test_getenv_port_auto(monkeypatch):
+    monkeypatch.setenv('TESTSUITE_TEST_PORT_AUTO', 'auto')
+    port = utils.getenv_port(key='TESTSUITE_TEST_PORT_AUTO', default=1234)
+    assert 0 < port < 65536
+    assert port != 1234
+    assert (
+        utils.getenv_port(key='TESTSUITE_TEST_PORT_AUTO', default=1234) == port
+    )
+
+
+def test_getenv_port_auto_per_key(monkeypatch):
+    monkeypatch.setenv('TESTSUITE_TEST_PORT_AUTO_A', 'auto')
+    monkeypatch.setenv('TESTSUITE_TEST_PORT_AUTO_B', 'auto')
+    port_a = utils.getenv_port(key='TESTSUITE_TEST_PORT_AUTO_A', default=1234)
+    port_b = utils.getenv_port(key='TESTSUITE_TEST_PORT_AUTO_B', default=1234)
+    assert port_a != port_b

--- a/testsuite/databases/pgsql/service.py
+++ b/testsuite/databases/pgsql/service.py
@@ -25,7 +25,7 @@ class ServiceSettings(typing.NamedTuple):
 
 def get_service_settings():
     return ServiceSettings(
-        utils.getenv_int(
+        utils.getenv_port(
             key='TESTSUITE_POSTGRESQL_PORT',
             default=DEFAULT_PORT,
         ),

--- a/testsuite/environment/utils.py
+++ b/testsuite/environment/utils.py
@@ -4,6 +4,10 @@ import time
 
 DOCKERTEST_WORKER = os.getenv('DOCKERTEST_WORKER', '')
 
+PORT_AUTO = 'auto'
+
+_auto_ports: dict[str, int] = {}
+
 
 class BaseError(Exception):
     pass
@@ -67,6 +71,36 @@ def getenv_int(key: str, default: int) -> int:
         ) from err
     else:
         return result
+
+
+def getenv_port(key: str, default: int) -> int:
+    """Resolve port number from environment variable.
+
+    Value ``auto`` allocates a free port. The allocated port is cached,
+    repeated calls with the same ``key`` return the same port within one
+    process.
+    """
+    env_value = os.getenv(key)
+    if env_value == PORT_AUTO:
+        if key not in _auto_ports:
+            _auto_ports[key] = _allocate_free_port(
+                exclude=set(_auto_ports.values()),
+            )
+        return _auto_ports[key]
+    return getenv_int(key, default)
+
+
+def _allocate_free_port(exclude: set[int]) -> int:
+    for _ in range(100):
+        sock = socket.socket()
+        try:
+            sock.bind(('localhost', 0))
+            port = sock.getsockname()[1]
+        finally:
+            sock.close()
+        if port not in exclude:
+            return port
+    raise BaseError('Failed to allocate free port')
 
 
 def getenv_float(key: str, default: float) -> float:


### PR DESCRIPTION
Fixed port 15433 makes it impossible to run two isolated environments on one machine: `--env-dir` separates state directories, but both sessions still fight over the same postgres port.

This adds special value `auto` for `TESTSUITE_POSTGRESQL_PORT`: a free port is allocated on first use and cached per environment variable within the process, so report header, fixtures and service settings agree on the same port. Ports already handed out to other keys are excluded to avoid collisions between databases in one process.

Explicit port values and the default are unchanged, the feature is opt-in.

Usage:

```sh
TESTSUITE_POSTGRESQL_PORT=auto pytest --env-dir=/tmp/env1 ...
```

If this shape looks good I will follow up with the same support for the other database plugins.