### PR TITLE
Declare nofilldb marker

### DIFF
--- a/tests/databases/mongodb/test_db.py
+++ b/tests/databases/mongodb/test_db.py
@@ -14,6 +14,11 @@ def test_db_simple(mongodb):
     }
 
 
+@pytest.mark.nofilldb
+def test_db_nofilldb_marker_registered():
+    pass
+
+
 @pytest.mark.filldb(foo='own_fixture')
 def test_db_own_fixture(mongodb):
     assert mongodb.foo.find_one('unknown') is None

--- a/testsuite/databases/mongo/pytest_plugin.py
+++ b/testsuite/databases/mongo/pytest_plugin.py
@@ -101,6 +101,10 @@ class CollectionWrapperFactory:
 def pytest_configure(config):
     config.addinivalue_line(
         'markers',
+        'nofilldb: disable MongoDB fixture-data loading for marked test',
+    )
+    config.addinivalue_line(
+        'markers',
         'noshuffledb: disable data set shuffle for marked test',
     )
     config.addinivalue_line(


### PR DESCRIPTION
Fixes warnings in tests that use this marker:

```
PytestUnknownMarkWarning: Unknown pytest.mark.nofilldb - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
```